### PR TITLE
Seems to have fixed the broken Travis test

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -40,7 +40,8 @@ RUN rm -rf build && mkdir build
 WORKDIR /home/flecsi/tpl/build
 RUN  cmake .. 
 USER root
-RUN make VERBOSE=1 -j
+RUN rm -rf /usr/local/include/legion* /usr/local/include/realm*
+RUN make VERBOSE=1 -j2
 USER flecsi
 
 #build flecsi
@@ -52,8 +53,8 @@ RUN  cmake .. -DFLECSI_RUNTIME_MODEL=legion \
               -DENABLE_LEGION=ON \
               -DENABLE_CLOG=OFF \
               -DENABLE_MPI=ON \
-              -DENABLE_MPI_CXX_BINDINGS=ON \
-  && make VERBOSE=1 -j2
+              -DENABLE_MPI_CXX_BINDINGS=ON 
+RUN make VERBOSE=1 -j2
 USER root
 RUN make install
 USER flecsi

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -30,6 +30,19 @@ RUN chown -R flecsi:flecsi /home/flecsi/flecsph /home/flecsi/.ccache /home/flecs
 RUN yum install -y which; exit 0
 USER flecsi
 
+#rebuild flecsi-third-party
+WORKDIR /home/flecsi/tpl
+RUN git config remote.origin.fetch "+refs/heads/*:refs/remotes/origin/*"
+RUN git fetch origin FleCSPH
+RUN git checkout FleCSPH
+RUN git submodule update --recursive
+RUN rm -rf build && mkdir build
+WORKDIR /home/flecsi/tpl/build
+RUN  cmake .. 
+USER root
+RUN make VERBOSE=1 -j
+USER flecsi
+
 #build flecsi
 WORKDIR /home/flecsi
 RUN git clone -b FleCSPH --depth 1 --recursive https://github.com/laristra/flecsi flecsi 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -48,7 +48,12 @@ WORKDIR /home/flecsi
 RUN git clone -b FleCSPH --depth 1 --recursive https://github.com/laristra/flecsi flecsi 
 RUN  cd flecsi && mkdir build && cd build
 WORKDIR flecsi/build
-RUN  cmake -DFLECSI_RUNTIME_MODEL=legion -DENABLE_CLOG=OFF .. && make VERBOSE=1 -j2
+RUN  cmake .. -DFLECSI_RUNTIME_MODEL=legion \
+              -DENABLE_LEGION=ON \
+              -DENABLE_CLOG=OFF \
+              -DENABLE_MPI=ON \
+              -DENABLE_MPI_CXX_BINDINGS=ON \
+  && make VERBOSE=1 -j2
 USER root
 RUN make install
 USER flecsi


### PR DESCRIPTION
Changes:
- modified Dockerfile to check out the compatible branch of flecsi-third-party;
- removed files in /usr/local/include left over from newer version;
- recompiled tpl.

What do you think? Perhaps a better solution would be to have the dependencies (flecsi + tpl) precompiled and shipped in the initial Docker image?