### PR TITLE
Restructure

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,16 +203,33 @@ To compile your project, you need to add it in `flecsph/config/project.cmake`: A
 
 Then, `cmake` links your project and you can compile it. 
 
+# Style guide
+
+FleCSPH follows the FleCSI coding style, which in turn follows (in general) the Google coding conventions.
+FleCSI coding style is documented here:
+https://github.com/laristra/flecsi/blob/master/flecsi/style.md
+
 # Logs 
 
 Cinch Log is the logging tool for this project. 
 In order to display log set the environement variable as: 
-```{engine=sh} 
+```bash 
 export CLOG_ENABLE_STDLOG=1
 ```
 
-You can set the level of output from trace, info, warn, error and fatal.
-Refer to the documentation at: 
+In the code, you can set the level of output from trace(0) and info(1) to warn(2), error(3) and fatal(4).
+You can then control the level of output at compile time by setting the flag `CLOG_STRIP_LEVEL`:
+by default it is set to 0 (trace), but for simulations it is perhaps preferrable to set it to 1 (info).
+In the code, if you only want a single rank (e.g. rank 0) to output, you need to use `clog_one` command,
+and indicate the output rank using the `clog_set_output_rank(rank)` macro right after MPI initialization:
+```cpp
+clog_set_output_rank(0);
+clog_one(info) << "This is essential output (level 1)" << std::endl;
+clog_one(trace) << "This is verbose output  (level 0)" << std::endl;
+clog_one(fatal) << "Farewell!" << std::endl; 
+```
+
+For further details, refer to the documentation at: 
 https://github.com/laristra/cinch/blob/master/logging/README.md
 
  # Contacts

--- a/app/bns_3D/main_driver.cc
+++ b/app/bns_3D/main_driver.cc
@@ -61,6 +61,7 @@ mpi_init_task(int startiteration = 0, int maxiter = 1000, double macangle = 0){
   int size;
   MPI_Comm_size(MPI_COMM_WORLD,&size);
   MPI_Comm_rank(MPI_COMM_WORLD,&rank);
+  clog_set_output_rank(0);
   
   physics::iteration = startiteration; 
   int noutput = 0;//startiteration+1;
@@ -96,7 +97,7 @@ mpi_init_task(int startiteration = 0, int maxiter = 1000, double macangle = 0){
   bs.setMacangle(macangle);
   bs.setMaxmasscell(10e-5);
 
-  clog(trace)<<"MacAngle="<<macangle<<std::endl;
+  clog_one(trace)<<"MacAngle="<<macangle<<std::endl;
 
   point_t momentum = {};
 
@@ -108,8 +109,8 @@ mpi_init_task(int startiteration = 0, int maxiter = 1000, double macangle = 0){
       });
 
   }else{
-    clog(info) << "Recomputing A from u"<<std::endl; 
-    clog(info) << "Considering velocityHalf = velocity" << std::endl;
+    clog_one(info) << "Recomputing A from u"<<std::endl; 
+    clog_one(info) << "Considering velocityHalf = velocity" << std::endl;
     // Convert internal energy to A ratio 
     bs.apply_all(physics::compute_adiabatic_from_internal_energy);
     bs.apply_all([](body_holder* source){
@@ -125,16 +126,15 @@ mpi_init_task(int startiteration = 0, int maxiter = 1000, double macangle = 0){
   ++(physics::iteration); 
   do
   { 
-    MPI_Barrier(MPI_COMM_WORLD);
     start_iteration = omp_get_wtime();
-    clog(info)<<"#### Iteration "<<physics::iteration<<std::endl;
+    analysis::screen_output();
     MPI_Barrier(MPI_COMM_WORLD);
 
     // Integration step
-    clog(info)<<"Leapfrog integration"<<std::flush; 
+    clog_one(trace)<<"Leapfrog integration"<<std::flush; 
     start = omp_get_wtime(); 
     bs.apply_all(physics::leapfrog_integration);
-    clog(info)<<".done "<< omp_get_wtime() - start << "s" <<std::endl;
+    clog_one(trace)<<".done "<< omp_get_wtime() - start << "s" <<std::endl;
 
     // Get rid of distant particles for faster run 
     bs.apply_all([](body_holder* source){
@@ -155,10 +155,10 @@ mpi_init_task(int startiteration = 0, int maxiter = 1000, double macangle = 0){
 
 #if RELAXATION == 0
     // Rotation of the stars
-    clog(info)<<"Rotation"<<std::flush; 
+    clog_one(trace)<<"Rotation"<<std::flush; 
     start = omp_get_wtime(); 
     bs.apply_all(physics::apply_rotation);
-    clog(info)<<".done "<< omp_get_wtime() - start << "s" <<std::endl;
+    clog_one(trace)<<".done "<< omp_get_wtime() - start << "s" <<std::endl;
 #endif
 
     // Compute and prepare the tree for this iteration 
@@ -172,11 +172,11 @@ mpi_init_task(int startiteration = 0, int maxiter = 1000, double macangle = 0){
     bs.update_iteration();
 
     MPI_Barrier(MPI_COMM_WORLD);
-    clog(info)<<"compute_density_pressure_adiabatic_soundspeed"<<std::flush; 
+    clog_one(trace)<<"compute_density_pressure_adiabatic_soundspeed"<<std::flush; 
     start = omp_get_wtime(); 
     bs.apply_in_smoothinglength(
       physics::compute_density_pressure_adiabatic_soundspeed); 
-    clog(info)<<".done "<< omp_get_wtime() - start << "s" <<std::endl;
+    clog_one(trace)<<".done "<< omp_get_wtime() - start << "s" <<std::endl;
 
     bs.update_neighbors();
 
@@ -186,46 +186,46 @@ mpi_init_task(int startiteration = 0, int maxiter = 1000, double macangle = 0){
     });
 
 
-    clog(info)<<"Accel FMM"<<std::flush; 
+    clog_one(trace)<<"Accel FMM"<<std::flush; 
     start = omp_get_wtime(); 
     bs.gravitation_fmm();
-    clog(info)<<".done "<< omp_get_wtime() - start << "s" <<std::endl;
+    clog_one(trace)<<".done "<< omp_get_wtime() - start << "s" <<std::endl;
 
-    clog(info)<<"Accel hydro"<<std::flush; 
+    clog_one(trace)<<"Accel hydro"<<std::flush; 
     start = omp_get_wtime(); 
     bs.apply_in_smoothinglength(physics::compute_hydro_acceleration);
-    clog(info)<<".done "<< omp_get_wtime() - start << "s" <<std::endl;
+    clog_one(trace)<<".done "<< omp_get_wtime() - start << "s" <<std::endl;
 
-    clog(info)<<"dadt"<<std::flush; 
+    clog_one(trace)<<"dadt"<<std::flush; 
     start = omp_get_wtime(); 
     bs.apply_in_smoothinglength(physics::compute_dadt);
-    clog(info)<<".done "<< omp_get_wtime() - start << "s" <<std::endl;
+    clog_one(trace)<<".done "<< omp_get_wtime() - start << "s" <<std::endl;
 
 #if RELAXATION == 1
-    clog(info)<<"Accel rot"<<std::flush; 
+    clog_one(trace)<<"Accel rot"<<std::flush; 
     start = omp_get_wtime(); 
     bs.get_all(physics::compute_QZZ);
     // Reduce QZZ
     MPI_Allreduce(MPI_IN_PLACE,&physics::QZZ,1,MPI_DOUBLE,MPI_SUM,MPI_COMM_WORLD);
     bs.get_all(physics::compute_rotation);
-    clog(info)<<".done "<< omp_get_wtime() - start << "s" <<std::endl;
+    clog_one(trace)<<".done "<< omp_get_wtime() - start << "s" <<std::endl;
  #endif
 
     // Compute the new DT 
     physics::dt = 1.0;
-    clog(info)<<"DT computation"<<std::flush; 
+    clog_one(trace)<<"DT computation"<<std::flush; 
     start = omp_get_wtime(); 
     bs.apply_in_smoothinglength(physics::compute_dt);
     mpi_utils::reduce_min(physics::dt);
 
-    clog(info)<<".done "<< omp_get_wtime() - start << "s" <<std::endl;
-    clog(info)<<"dt="<<physics::dt<<std::endl;
+    clog_one(trace)<<".done "<< omp_get_wtime() - start << "s" <<std::endl;
+    clog_one(trace)<<"dt="<<physics::dt<<std::endl;
     assert(physics::dt != 1.0);
     physics::totaltime += physics::dt;
 
     // Compute internal energy for output 
     bs.apply_all(physics::compute_internal_energy_from_adiabatic);
-    clog(info)<<"Total time="<<physics::totaltime<<"s / "<<maxtime<<"s"
+    clog_one(trace)<<"Total time="<<physics::totaltime<<"s / "<<maxtime<<"s"
       <<std::endl;
 
 #ifdef OUTPUT_ANALYSIS
@@ -237,8 +237,7 @@ mpi_init_task(int startiteration = 0, int maxiter = 1000, double macangle = 0){
       // Output 
       noutput_analysis++;
       // Only add the header in the first iteration
-      analysis::display("analysis_bns_3D.dat",
-        physics::iteration == startiteration+1);
+      analysis::scalar_output("scalar.dat");
       
     }
 #endif
@@ -255,7 +254,7 @@ mpi_init_task(int startiteration = 0, int maxiter = 1000, double macangle = 0){
     ++(physics::iteration);
     
     MPI_Barrier(MPI_COMM_WORLD);
-    clog(info)<<"Iteration time = "<<omp_get_wtime()-start_iteration<< "s" 
+    clog_one(trace)<<"Iteration time = "<<omp_get_wtime()-start_iteration<< "s" 
       <<std::endl;
   }while(physics::iteration<maxiter);
   //}while(physics::totaltime<physics::maxtime);
@@ -266,7 +265,7 @@ flecsi_register_mpi_task(mpi_init_task);
 void 
 usage()
 {
-  clog(warn)<<"Usage:"<<std::endl<<
+  clog_one(warn)<<"Usage:"<<std::endl<<
     "./bns_3D [Starting iteration] [Max interation] [MAC Angle]"<<std::endl;
 }
 
@@ -292,13 +291,13 @@ specialization_tlt_init(int argc, char * argv[]){
     macangle = atof(argv[3]);
   }
 
-  clog(warn) << "In user specialization_driver" << std::endl;
+  clog_one(warn) << "In user specialization_driver" << std::endl;
   flecsi_execute_mpi_task(mpi_init_task,startiteration,maxiter,macangle); 
 } // specialization driver
 
 void 
 driver(int argc,  char * argv[]){
-  clog(warn) << "In user driver" << std::endl;
+  clog_one(warn) << "In user driver" << std::endl;
 } // driver
 
 

--- a/app/bwd/main_driver.cc
+++ b/app/bwd/main_driver.cc
@@ -40,6 +40,7 @@
 #include <bodies_system.h>
 
 #include "default_physics.h"
+#include "analysis.h"
 
 namespace flecsi{
 namespace execution{
@@ -52,12 +53,12 @@ mpi_init_task(int startiteration){
   int size;
   MPI_Comm_size(MPI_COMM_WORLD,&size);
   MPI_Comm_rank(MPI_COMM_WORLD,&rank);
+  clog_set_output_rank(0);
   
   int totaliters = 100;
   int iteroutput = 1;
   double totaltime = 0.0;
   double maxtime = 10.0;
-  int iter = startiteration; 
 
   // Init if default values are not ok
   physics::dt = 1.0e-10;
@@ -75,14 +76,13 @@ mpi_init_task(int startiteration){
   physics::epsilon = 0.01*h*h;
 
 #ifdef OUTPUT
-  bs.write_bodies("output_bwd",iter);
+  bs.write_bodies("output_bwd",physics::iteration);
 #endif
 
-  ++iter; 
+  ++physics::iteration; 
   do
   { 
-    MPI_Barrier(MPI_COMM_WORLD);
-    clog(info)<<"#### Iteration "<<iter<<std::endl;
+    analysis::screen_output();
     MPI_Barrier(MPI_COMM_WORLD);
 
     // Compute and prepare the tree for this iteration 
@@ -96,56 +96,56 @@ mpi_init_task(int startiteration){
     bs.update_iteration();
    
     // Do the DWD physics
-    clog(info)<<"Density"<<std::flush; 
+    clog_one(trace)<<"Density"<<std::flush; 
     bs.apply_in_smoothinglength(physics::compute_density);
-    clog(info)<<".done"<<std::endl;
+    clog_one(trace)<<".done"<<std::endl;
 
-    clog(info)<<"Pressure"<<std::flush; 
+    clog_one(trace)<<"Pressure"<<std::flush; 
     bs.apply_all(physics::compute_pressure_wd);
-    clog(info)<<".done"<<std::endl;
+    clog_one(trace)<<".done"<<std::endl;
 
-    clog(info)<<"Linear Momentum"<<std::flush; 
+    clog_one(trace)<<"Linear Momentum"<<std::flush; 
     //bs.apply_all(physics::compute_lin_momentum);
-    clog(info)<<".done"<<std::endl;
+    clog_one(trace)<<".done"<<std::endl;
 
-    clog(info)<<"Soundspeed"<<std::flush; 
+    clog_one(trace)<<"Soundspeed"<<std::flush; 
     bs.apply_all(physics::compute_soundspeed);
-    clog(info)<<".done"<<std::endl;
+    clog_one(trace)<<".done"<<std::endl;
     
     // Refresh the neighbors within the smoothing length 
     bs.update_neighbors(); 
 
-    clog(info)<<"Hydro acceleration"<<std::flush; 
+    clog_one(trace)<<"Hydro acceleration"<<std::flush; 
     bs.apply_in_smoothinglength(physics::compute_hydro_acceleration);
-    clog(info)<<".done"<<std::endl;
+    clog_one(trace)<<".done"<<std::endl;
  
-    clog(info)<<"Internalenergy"<<std::flush; 
+    clog_one(trace)<<"Internalenergy"<<std::flush; 
     bs.apply_in_smoothinglength(physics::compute_dudt);
-    clog(info)<<".done"<<std::endl; 
+    clog_one(trace)<<".done"<<std::endl; 
    
-    if(iter==1){ 
-      clog(info)<<"leapfrog"<<std::flush; 
+    if(physics::iteration==1){ 
+      clog_one(trace)<<"leapfrog"<<std::flush; 
       bs.apply_all(physics::leapfrog_integration_first_step);
-      clog(info)<<".done"<<std::endl;
+      clog_one(trace)<<".done"<<std::endl;
     }else{
-      clog(info)<<"leapfrog"<<std::flush; 
+      clog_one(trace)<<"leapfrog"<<std::flush; 
       bs.apply_all(physics::leapfrog_integration);
-      clog(info)<<".done"<<std::endl;
+      clog_one(trace)<<".done"<<std::endl;
     }
 
-    clog(info)<<"dudt integration"<<std::flush; 
+    clog_one(trace)<<"dudt integration"<<std::flush; 
     bs.apply_all(physics::dudt_integration);
-    clog(info)<<".done"<<std::endl;
+    clog_one(trace)<<".done"<<std::endl;
 
    
 #ifdef OUTPUT
-    if(iter % iteroutput == 0){ 
-      bs.write_bodies("output_bwd",iter/iteroutput);
+    if(physics::iteration % iteroutput == 0){ 
+      bs.write_bodies("output_bwd",physics::iteration/iteroutput);
     }
 #endif
-    ++iter;
+    ++physics::iteration;
     
-  }while(iter<totaliters);
+  }while(physics::iteration<totaliters);
 }
 
 flecsi_register_mpi_task(mpi_init_task);
@@ -159,14 +159,14 @@ specialization_tlt_init(int argc, char * argv[]){
     startiteration = atoi(argv[1]);
   }
 
-  clog(warn) << "In user specialization_driver" << std::endl;
+  clog_one(warn) << "In user specialization_driver" << std::endl;
 
   flecsi_execute_mpi_task(mpi_init_task,startiteration); 
 } // specialization driver
 
 void 
 driver(int argc,  char * argv[]){
-  clog(warn) << "In user driver" << std::endl;
+  clog_one(warn) << "In user driver" << std::endl;
 } // driver
 
 

--- a/app/fluid_2D/generator/main.cc
+++ b/app/fluid_2D/generator/main.cc
@@ -3,7 +3,7 @@
  * All rights reserved.
  *~--------------------------------------------------------------------------~*/
 
- #include <iostream>
+#include <iostream>
 #include <algorithm>
 #include <cmath>
 #include <cassert>
@@ -30,7 +30,7 @@ void generate_wall(
     double x1, double y1,
     double ldistance){
   double dist_points = sqrt((x1-x0)*(x1-x0)+(y1-y0)*(y1-y0));
-  clog(info)<<"Distance: "<<dist_points<<std::endl;
+  clog_one(info)<<"Distance: "<<dist_points<<std::endl;
   int nelements = dist_points/ldistance;
   double xcur = x0;
   double ycur = y0;
@@ -59,7 +59,7 @@ int main(int argc, char * argv[]){
   int provided; 
   MPI_Init_thread(&argc,&argv,MPI_THREAD_MULTIPLE,&provided);
   if(provided<MPI_THREAD_MULTIPLE){
-	 clog(error)<<"Error MPI version: MPI_THREAD_MULTIPLE provided: "
+	 clog_one(error)<<"Error MPI version: MPI_THREAD_MULTIPLE provided: "
     <<provided<<std::endl;
     MPI_Finalize(); 
 	 exit(EXIT_FAILURE); 	
@@ -67,10 +67,11 @@ int main(int argc, char * argv[]){
  
   MPI_Comm_rank(MPI_COMM_WORLD,&rank);
   MPI_Comm_size(MPI_COMM_WORLD,&size);
+  clog_set_output_rank(0);
 
   // Use only one process for generation in this version
   if(size > 1){
-    clog(error)<<
+    clog_one(error)<<
         "Use only one process for generation in this version"<<std::endl;
     MPI_Finalize();
     exit(EXIT_FAILURE);
@@ -80,8 +81,8 @@ int main(int argc, char * argv[]){
   int ny = 10;//atoi(argv[2]);
 
   if(argc!=3){
-    clog(warn)<<"./fluid_generator nx ny"<<std::endl;
-    clog(warn)<<"Generation with default values= 10*10=100 particles"<<std::endl;
+    clog_one(warn)<<"./fluid_generator nx ny"<<std::endl;
+    clog_one(warn)<<"Generation with default values= 10*10=100 particles"<<std::endl;
   }else{
     nx = atoi(argv[1]);
     ny = atoi(argv[2]);
@@ -93,8 +94,8 @@ int main(int argc, char * argv[]){
     nparticlesproc = nparticles - nparticlesproc*(size-1);
   }
 
-  clog(info)<<"Generating "<<nparticles<<" particles "<<std::endl;
-  clog(info)<<nparticlesproc<<" particles per proc (last "<<
+  clog_one(info)<<"Generating "<<nparticles<<" particles "<<std::endl;
+  clog_one(info)<<nparticlesproc<<" particles per proc (last "<<
     nparticles-nparticlesproc*(size-1)<<")"<<std::endl;
  
   // Generate data
@@ -155,7 +156,7 @@ int main(int argc, char * argv[]){
     nwall_proc = nwall - nwall_proc*(size-1);
   }
 
-  clog(info)<<"Wall particles="<<nwall<<" per proc="<<nwall_proc <<std::endl; 
+  clog_one(info)<<"Wall particles="<<nwall<<" per proc="<<nwall_proc <<std::endl; 
 
   int64_t totalpart = nparticlesproc+nwall_proc; 
 
@@ -189,7 +190,7 @@ int main(int argc, char * argv[]){
   // Timestep 
   double* dt = new double[totalpart]();
 
-  clog(info)<<"Generating: "<<nlines<<"*"<<ncols<<std::endl;
+  clog_one(info)<<"Generating: "<<nlines<<"*"<<ncols<<std::endl;
 
   // Id of my first particle 
   int64_t posid = nparticlesproc*rank;
@@ -245,13 +246,13 @@ int main(int argc, char * argv[]){
 
   char filename[128];
   sprintf(filename,"%s.h5part",fileprefix);
-  clog(info)<<"Writing to: "<<filename<<std::endl;
+  clog_one(info)<<"Writing to: "<<filename<<std::endl;
   remove(filename);
 
   Flecsi_Sim_IO::HDF5ParticleIO testDataSet;
   testDataSet.createDataset(filename,MPI_COMM_WORLD);
   
-  clog(info)<<"Writing total of "<<nparticles+nwall<<" particles"<<std::endl
+  clog_one(info)<<"Writing total of "<<nparticles+nwall<<" particles"<<std::endl
     <<std::flush;
 
   // add the global attributes

--- a/app/fluid_2D/main_driver.cc
+++ b/app/fluid_2D/main_driver.cc
@@ -39,6 +39,7 @@
 
 #include "bodies_system.h"
 #include "fluids_physics.h"
+#include "analysis.h"
 
 namespace flecsi{
 namespace execution{
@@ -51,8 +52,8 @@ mpi_init_task(int startiteration){
   int size;
   MPI_Comm_size(MPI_COMM_WORLD,&size);
   MPI_Comm_rank(MPI_COMM_WORLD,&rank);
+  clog_set_output_rank(0);
   
-  int iter = startiteration; 
   int noutput = startiteration+1;
 
   body_system<double,gdimension> bs;
@@ -69,26 +70,25 @@ mpi_init_task(int startiteration){
   double start = 0;
 
   // Apply EOS once 
-  clog(info)<<"Init EOS"<<std::flush; 
+  clog_one(trace)<<"Init EOS"<<std::flush; 
   start = omp_get_wtime(); 
   bs.apply_all(physics::EOS); 
-  clog(info)<<".done "<< omp_get_wtime() - start << "s" <<std::endl;
+  clog_one(trace)<<".done "<< omp_get_wtime() - start << "s" <<std::endl;
 
   // Apply EOS once 
-  clog(info)<<"Init Density Velocity"<<std::flush; 
+  clog_one(trace)<<"Init Density Velocity"<<std::flush; 
   start = omp_get_wtime(); 
   bs.apply_all(physics::init_density_velocity); 
-  clog(info)<<".done "<< omp_get_wtime() - start << "s" <<std::endl;
+  clog_one(trace)<<".done "<< omp_get_wtime() - start << "s" <<std::endl;
 
 #ifdef OUTPUT
   bs.write_bodies("output_fluid_2D",startiteration);
 #endif
 
-  ++iter; 
+  ++physics::iteration; 
   do
   { 
-    MPI_Barrier(MPI_COMM_WORLD);
-    clog(info)<<"#### Iteration "<<iter<<std::endl;
+    analysis::screen_output();
     MPI_Barrier(MPI_COMM_WORLD);
 
     // Compute and prepare the tree for this iteration 
@@ -101,28 +101,28 @@ mpi_init_task(int startiteration){
     // - Compute and exchange ghosts in real smoothing length 
     bs.update_iteration();
     
-    clog(info)<<"Accel"<<std::flush; 
+    clog_one(trace)<<"Accel"<<std::flush; 
     start = omp_get_wtime(); 
     bs.apply_in_smoothinglength(physics::compute_accel);
-    clog(info)<<".done "<< omp_get_wtime() - start << "s" <<std::endl;
+    clog_one(trace)<<".done "<< omp_get_wtime() - start << "s" <<std::endl;
 
 
-    clog(info)<<"DT"<<std::flush; 
+    clog_one(trace)<<"DT"<<std::flush; 
     start = omp_get_wtime(); 
     bs.get_all(physics::update_dt); 
-    clog(info)<<".done "<< omp_get_wtime() - start << "s" <<std::endl;
+    clog_one(trace)<<".done "<< omp_get_wtime() - start << "s" <<std::endl;
 
     // Reduce the local DT 
     MPI_Allreduce(MPI_IN_PLACE,&physics::dt,1,MPI_DOUBLE,MPI_MIN,MPI_COMM_WORLD); 
-    clog(info)<<"New DT = "<<physics::dt<<std::endl;
+    clog_one(trace)<<"New DT = "<<physics::dt<<std::endl;
 
-    clog(info)<<"Verlet integration EOS"<<std::flush; 
+    clog_one(trace)<<"Verlet integration EOS"<<std::flush; 
     start = omp_get_wtime(); 
     bs.apply_all(physics::verlet_integration_EOS);
-    clog(info)<<".done "<< omp_get_wtime() - start << "s" <<std::endl;
+    clog_one(trace)<<".done "<< omp_get_wtime() - start << "s" <<std::endl;
 
     physics::totaltime += physics::dt;
-    clog(info)<<"Total time="<<physics::totaltime<<"s / "<<physics::maxtime<<"s"<<std::endl;
+    clog_one(trace)<<"Total time="<<physics::totaltime<<"s / "<<physics::maxtime<<"s"<<std::endl;
 
 #ifdef OUTPUT
     if(physics::totaltime > noutput*physics::outputtime){
@@ -130,7 +130,7 @@ mpi_init_task(int startiteration){
       noutput++;
     }
 #endif
-    ++iter;
+    ++physics::iteration;
     
     
   }while(physics::totaltime<physics::maxtime);
@@ -147,14 +147,14 @@ specialization_tlt_init(int argc, char * argv[]){
     startiteration = atoi(argv[1]);
   }
 
-  clog(trace) << "In user specialization_driver" << std::endl;
+  clog_one(trace) << "In user specialization_driver" << std::endl;
 
   flecsi_execute_mpi_task(mpi_init_task,startiteration); 
 } // specialization driver
 
 void 
 driver(int argc,  char * argv[]){
-  clog(trace) << "In user driver" << std::endl;
+  clog_one(trace) << "In user driver" << std::endl;
 } // driver
 
 

--- a/app/fluid_3D/generator/main.cc
+++ b/app/fluid_3D/generator/main.cc
@@ -22,14 +22,22 @@ int32_t dimension = 3;
 
 int main(int argc, char * argv[]){
  
+  int rank, size; 
+  int provided; 
+  MPI_Init_thread(&argc,&argv,MPI_THREAD_MULTIPLE,&provided);
+  assert(provided>=MPI_THREAD_MULTIPLE); 
+  MPI_Comm_rank(MPI_COMM_WORLD,&rank);
+  MPI_Comm_size(MPI_COMM_WORLD,&size);
+  clog_set_output_rank(0);
+
   int nx = 10;//atoi(argv[1]);
   int ny = 10;//atoi(argv[2]);
   int nz = 10;//atoi(argv[3]);
 
 
   if(argc!=4){
-    clog(warn)<<"./fluid_generator nx ny nz"<<std::endl;
-    clog(warn)<<"Generation with default values= 10*10*10=1000 particles"
+    clog_one(warn)<<"./fluid_generator nx ny nz"<<std::endl;
+    clog_one(warn)<<"Generation with default values= 10*10*10=1000 particles"
       <<std::endl;
   }else{
     nx = atoi(argv[1]);
@@ -37,21 +45,14 @@ int main(int argc, char * argv[]){
     nz = atoi(argv[3]);
   }
 
-  int rank, size; 
-  int provided; 
-  MPI_Init_thread(&argc,&argv,MPI_THREAD_MULTIPLE,&provided);
-  assert(provided>=MPI_THREAD_MULTIPLE); 
-  MPI_Comm_rank(MPI_COMM_WORLD,&rank);
-  MPI_Comm_size(MPI_COMM_WORLD,&size);
-
   int64_t nparticles = nx*ny*nz;
   int64_t nparticlesproc = nparticles/size;
   if(rank==size-1){
     nparticlesproc = nparticles - nparticlesproc*(size-1);
   }
 
-  clog(info)<<"Generating "<<nparticles<<" particles"<<std::endl;
-  clog(info)<<nparticlesproc<<" particles per proc (last "<<
+  clog_one(info)<<"Generating "<<nparticles<<" particles"<<std::endl;
+  clog_one(info)<<nparticlesproc<<" particles per proc (last "<<
     nparticles-nparticlesproc*(size-1)<<")"<<std::endl;
 
   if(nz == 0){
@@ -92,7 +93,7 @@ int main(int argc, char * argv[]){
   double linestart = rank * nlinesproc * ldistance;
   double ndepth = nz;
 
-  clog(info)<<"Generating: "<<nlines<<"*"<<ncols<<std::endl;
+  clog_one(info)<<"Generating: "<<nlines<<"*"<<ncols<<std::endl;
 
   // Id of my first particle 
   int64_t posid = nparticlesproc*rank;

--- a/app/noh/generator/main.cc
+++ b/app/noh/generator/main.cc
@@ -50,13 +50,6 @@ int main(int argc, char * argv[]){
 
   int64_t sparticles = 100;         // Default number of particles
 
-  if (argc != 2) {
-    clog(warn) << "./noh_generator [square nParticles]\n" << std::endl;
-    clog(warn) << "Generating default number of particles"<<
-      sparticles<<"*"<<sparticles<<"="<<sparticles*sparticles<<std::endl;
-  }
-  else sparticles = atoll(argv[1]);
-
   int rank, size; 
   int provided; 
 
@@ -64,6 +57,16 @@ int main(int argc, char * argv[]){
   assert(provided>=MPI_THREAD_MULTIPLE); 
   MPI_Comm_rank(MPI_COMM_WORLD,&rank);
   MPI_Comm_size(MPI_COMM_WORLD,&size);
+  clog_set_output_rank(0);
+
+  if (argc != 2) {
+    clog_one(warn) << "WARNING: number of particles not specitifed!" << std::endl
+                   << "Usage: ./noh_generator [sqrt {nParticles}]"   << std::endl
+                   << "Generating default number of particles: "     
+                   << sparticles<<"*"<<sparticles << " => "
+                   << sparticles*sparticles << std::endl;
+  }
+  else sparticles = atoll(argv[1]);
 
 
   // Total number of initialized particles
@@ -79,10 +82,10 @@ int main(int argc, char * argv[]){
   // Particle mass given the initial density and number of particles
   double m_in = rho_in * radius * radius * 4.0 / nparticles; 
 
-  clog(info)<<"Sphere: r="<<radius<<" pos=["<<x_c<<";"<<y_c<<"]"<<std::endl;
-
-  clog(info) << "Generating" <<nparticles<<" particles by "<<
-    sparticles<<"x"<<sparticles<<" in sphere r="<<radius<<std::endl;
+  clog_one(info) << "Sphere: r=" << radius << std::endl
+                 << "origin: pos=["<<x_c<<";"<<y_c<<"]" << std::endl
+                 << "Generating "  << nparticles 
+                 << " particles (="<< sparticles<<"^2) " << std::endl;
 
 
   // Start on  0 0
@@ -139,8 +142,8 @@ int main(int argc, char * argv[]){
   double timestep = 0.001;
   int dimension = 2;
   
-  clog(info) << "top_X=" << x_topproc << " top_Y=" << y_topproc << 
-    " maxX=" << maxxposition << " maxY=" << maxyposition << std::endl;
+  clog_one(info) << "top_X=" << x_topproc << " top_Y="  << y_topproc    << std::endl 
+                 << "maxX=" << maxxposition << " maxY=" << maxyposition << std::endl;
 
   double xposition = x_topproc; 
   double yposition = y_topproc;
@@ -211,7 +214,8 @@ int main(int argc, char * argv[]){
     }
   }
 
-  clog(info) << "Real Number of Particles: " << tparticles << std::endl;
+  clog_one(info) << "Actual number of particles inside the sphere: " 
+                 << tparticles << std::endl;
 
   char filename[128];
   sprintf(filename,"%s.h5part",fileprefix);

--- a/app/noh/main_driver.cc
+++ b/app/noh/main_driver.cc
@@ -39,6 +39,7 @@
 
 #include "bodies_system.h"
 #include "default_physics.h"
+#include "analysis.h"
 
 namespace flecsi{
 namespace execution{
@@ -49,12 +50,13 @@ mpi_init_task(int startiteration){
   int size;
   MPI_Comm_size(MPI_COMM_WORLD,&size);
   MPI_Comm_rank(MPI_COMM_WORLD,&rank);
+  clog_set_output_rank(0);
   
   int totaliters   = 500;
   int iteroutput   = 10;
   double totaltime = 0.0;
   double maxtime   = 10.0;
-  int iter = startiteration; 
+  physics::iteration = startiteration; 
 
   // Init if default values are not ok
   physics::dt = 0.001;
@@ -71,13 +73,12 @@ mpi_init_task(int startiteration){
   remove("output_noh.h5part"); 
 
 #ifdef OUTPUT
-  bs.write_bodies("output_noh",iter);
+  bs.write_bodies("output_noh",physics::iteration);
 #endif
 
-  ++iter; 
+  ++physics::iteration; 
   do { 
-    MPI_Barrier(MPI_COMM_WORLD);
-    clog(info) << "#### Iteration " << iter << std::endl;
+    analysis::screen_output();
     MPI_Barrier(MPI_COMM_WORLD);
 
     // Compute and prepare the tree for this iteration 
@@ -91,48 +92,48 @@ mpi_init_task(int startiteration){
     bs.update_iteration();
    
     // Do the Noh physics
-    clog(info) << "compute_density_pressure_soundspeed" << std::flush; 
+    clog_one(trace) << "compute_density_pressure_soundspeed" << std::flush; 
     bs.apply_in_smoothinglength(physics::compute_density_pressure_soundspeed);
-    clog(info) << ".done" << std::endl;
+    clog_one(trace) << ".done" << std::endl;
     
     // Refresh the neighbors within the smoothing length 
     bs.update_neighbors(); 
 
-    clog(info) << "Hydro acceleration" << std::flush; 
+    clog_one(trace) << "Hydro acceleration" << std::flush; 
     bs.apply_in_smoothinglength(physics::compute_hydro_acceleration);
-    clog(info) << ".done" << std::endl;
+    clog_one(trace) << ".done" << std::endl;
  
-    clog(info) << "Internalenergy" << std::flush; 
+    clog_one(trace) << "Internalenergy" << std::flush; 
     bs.apply_in_smoothinglength(physics::compute_dudt);
-    clog(info) << ".done" << std::endl; 
+    clog_one(trace) << ".done" << std::endl; 
    
-    if (iter == 1){ 
-      clog(info) << "leapfrog" << std::flush; 
+    if (physics::iteration == 1){ 
+      clog_one(trace) << "leapfrog" << std::flush; 
       bs.apply_all(physics::leapfrog_integration_first_step);
-      clog(info) << ".done" << std::endl;
+      clog_one(trace) << ".done" << std::endl;
     }
     else{
-      clog(info) << "leapfrog" << std::flush; 
+      clog_one(trace) << "leapfrog" << std::flush; 
       bs.apply_all(physics::leapfrog_integration);
-      clog(info) << ".done" << std::endl;
+      clog_one(trace) << ".done" << std::endl;
     }
 
-    clog(info) <<"dudt integration"<<std::flush; 
+    clog_one(trace) <<"dudt integration"<<std::flush; 
     bs.apply_all(physics::dudt_integration);
-    clog(info) << ".done" << std::endl;
+    clog_one(trace) << ".done" << std::endl;
    
 
     physics::totaltime += physics::dt;
-    clog(info) << "Total time=" << physics::totaltime << "s / " << std::endl;
 
 #ifdef OUTPUT
-    if (iter % iteroutput == 0){ 
-      bs.write_bodies("output_noh",iter/iteroutput);
+// TODO: add scalar output
+    if (physics::iteration % iteroutput == 0){ 
+      bs.write_bodies("output_noh",physics::iteration/iteroutput);
     }
 #endif
-    ++iter;
+    ++physics::iteration;
     
-  }while(iter<totaliters);
+  }while(physics::iteration<totaliters);
 }
 
 
@@ -146,7 +147,7 @@ specialization_tlt_init(int argc, char * argv[]){
   if (argc == 2){
     startiteration = atoi(argv[1]);
   }
-  clog(trace) << "In user specialization_driver" << std::endl;
+  clog_one(trace) << "In user specialization_driver" << std::endl;
   flecsi_execute_mpi_task(mpi_init_task,startiteration); 
 } // specialization driver
 
@@ -154,7 +155,7 @@ specialization_tlt_init(int argc, char * argv[]){
 
 void 
 driver(int argc,  char * argv[]){
-  clog(trace) << "In user driver" << std::endl;
+  clog_one(trace) << "In user driver" << std::endl;
 } // driver
 
 

--- a/app/sedov/generator/main.cc
+++ b/app/sedov/generator/main.cc
@@ -3,7 +3,7 @@
  * All rights reserved.
  *~--------------------------------------------------------------------------~*/
 
- #include <iostream>
+#include <iostream>
 #include <algorithm>
 #include <cassert>
 
@@ -55,21 +55,22 @@ int main(int argc, char * argv[]){
   assert(provided>=MPI_THREAD_MULTIPLE); 
   MPI_Comm_rank(MPI_COMM_WORLD,&rank);
   MPI_Comm_size(MPI_COMM_WORLD,&size);
+  clog_set_output_rank(0);
 
   if (argc != 2) {
-    clog(warn) << "WARNING: you have not specified sqrt of the number of particles!" 
+    clog_one(warn) << "WARNING: you have not specified sqrt of the number of particles!" 
            << std::endl << "Usage: ./sedov_generator [sParticles]" << std::endl
            << " - generates initial conditions with  sParticles^2 particles."
            << std::endl << "Generating with the default value: sparticles = " 
            << sparticles << std::endl;
   }else{
     sparticles = atoll(argv[1]);
-    clog(info) << "Square root of the number of particles: sparticles = " 
+    clog_one(info) << "Square root of the number of particles: sparticles = " 
            << sparticles << std::endl;
   }
 
   int64_t nparticles = sparticles*sparticles;
-  clog(info) << "Generating " << nparticles << " particles" << std::endl;
+  clog_one(info) << "Generating " << nparticles << " particles" << std::endl;
 
   // Start on  0 0
 
@@ -139,7 +140,7 @@ int main(int argc, char * argv[]){
     }
   }
 
-  clog(info) << "Real number of particles: " << tparticles << std::endl;
+  clog_one(info) << "Real number of particles: " << tparticles << std::endl;
 
   char filename[128];
   //sprintf(filename,"%s_%d.h5part",fileprefix,nparticles);

--- a/app/sodtube/generator/main.cc
+++ b/app/sodtube/generator/main.cc
@@ -52,7 +52,7 @@ void set_default_param(int rank, int size) {
 //
 void print_usage(int rank) {
   using namespace std;
-  clog(warn) << "Initial data generator for Sod shocktube test in 1D" << endl
+  clog_one(warn) << "Initial data generator for Sod shocktube test in 1D" << endl
          << "Usage: ./sodtube_generator [OPTIONS]" << endl
          << " -h: this help" << endl
          << " -n <number of particles>" << endl
@@ -89,7 +89,7 @@ void parse_command_line_options(int rank, int size, int argc, char* argv[]) {
         break;
 
       default:
-        clog(error) << "ERROR: unknown option '-" << argv[i][1] << "'" << endl;
+        clog_one(error) << "ERROR: unknown option '-" << argv[i][1] << "'" << endl;
         MPI_Finalize();
         exit(-1);
 
@@ -149,7 +149,7 @@ void set_param(int rank, int size) {
       break;
 
     default:
-      clog(error) << "ERROR: invalid test (" << sodtest_num << ")." << endl;
+      clog_one(error) << "ERROR: invalid test (" << sodtest_num << ")." << endl;
       MPI_Finalize();
       exit(-1);
   }
@@ -170,6 +170,7 @@ int main(int argc, char * argv[]){
   assert(provided>=MPI_THREAD_MULTIPLE);
   MPI_Comm_rank(MPI_COMM_WORLD,&rank);
   MPI_Comm_size(MPI_COMM_WORLD,&size);
+  clog_set_output_rank(0);
 
   // set simulation parameters
   set_default_param(rank,size);
@@ -177,7 +178,7 @@ int main(int argc, char * argv[]){
   set_param(rank,size);
 
   // screen output
-  clog(info) << "Sod test #" << sodtest_num << " in 1D:" << endl
+  clog_one(info) << "Sod test #" << sodtest_num << " in 1D:" << endl
          << " - number of particles: " << nparticles << endl
          << " - particles per core:  " << nparticlesproc << endl
          << " - output file: " << output_filename << endl;

--- a/include/physics/analysis.h
+++ b/include/physics/analysis.h
@@ -4,7 +4,7 @@
  *~--------------------------------------------------------------------------~*/
 
  /*~--------------------------------------------------------------------------~*
- * 
+ *
  * /@@@@@@@@ @@           @@@@@@   @@@@@@@@ @@@@@@@  @@      @@
  * /@@///// /@@          @@////@@ @@////// /@@////@@/@@     /@@
  * /@@      /@@  @@@@@  @@    // /@@       /@@   /@@/@@     /@@
@@ -12,7 +12,7 @@
  * /@@////  /@@/@@@@@@@/@@       ////////@@/@@////  /@@//////@@
  * /@@      /@@/@@//// //@@    @@       /@@/@@      /@@     /@@
  * /@@      /@@@//@@@@@@ //@@@@@@  @@@@@@@@ /@@      /@@     /@@
- * //       ///  //////   //////  ////////  //       //      //  
+ * //       ///  //////   //////  ////////  //       //      //
  *
  *~--------------------------------------------------------------------------~*/
 
@@ -20,7 +20,7 @@
  * @file analysis.h
  * @author Julien Loiseau
  * @date April 2017
- * @brief Basic analysis 
+ * @brief Basic analysis
  */
 
 #ifndef _physics_analysis_h_
@@ -35,83 +35,101 @@ namespace analysis{
   point_t linear_momentum;
 
   /**
-   * @brief      Compute the linear momentum, 
+   * @brief      Compute the linear momentum,
    *
-   * @param      bodies  Vector of all the local bodies 
-   * @param      total   Total linear momentum 
-   */  
-  void 
+   * @param      bodies  Vector of all the local bodies
+   * @param      total   Total linear momentum
+   */
+  void
   compute_lin_momentum(
-      std::vector<body_holder*>& bodies) 
+      std::vector<body_holder*>& bodies)
   {
     linear_momentum = {0};
     for(auto nbh: bodies) {
-      linear_momentum += nbh->getBody()->getLinMomentum(); 
-    }  
+      linear_momentum += nbh->getBody()->getLinMomentum();
+    }
   }
 
-  void 
-  display(const char * filename = NULL, bool header = false)
+
+  /**
+   * @brief Rolling screen output
+   */
+  void
+  screen_output() 
   {
-    // TODO: output just a single line on a screen, containing iteration and time;
-    //       output all scalar reductions as single clearly formatted line to a 
-    //       file ("reductions.dat") as well as on the screen. When creating the 
-    //       file, write a header to indicate which quantities are output in which 
-    //       column (because their order and quantity may change between revisions)
-    //       E.g.:
-    //       -- >> example output file >> -----------------------------------------
-    //       # Scalar reductions:
-    //       # 1:iteration 2:time 3:energy 4:mom_x 5:mom_y 6:mom_z
-    //       0  0.0   1.0000000e+03  0.00000000e+00  0.00000000e+00  0.00000000e+00 
-    //       10 0.1   1.0000000e+03  0.00000000e+00  0.00000000e+00  0.00000000e+00 
-    //       20 0.2   1.0000000e+03  0.00000000e+00  0.00000000e+00  0.00000000e+00 
-    //       30 0.3   1.0000000e+03  0.00000000e+00  0.00000000e+00  0.00000000e+00 
-    //       ...
-    //       -- << end output file <<<< -------------------------------------------
-    
-    // For screen otuput, generate the header anyways 
-    std::ostringstream oss_header;
-    oss_header
-      << "# Scalar reductions: " <<std::endl
-      << "# 1:iteration 2:time 3:mom_x ";
-    // The momentum depends on dimension 
-    if(gdimension > 1){
-      oss_header<<"4:mom_y ";
+    const int screen_length = 40;  
+    (physics::iteration-1)%screen_length  ||
+    clog_one(info)<< "#-- iteration:               time:" <<std::endl;
+    clog_one(info)
+      << std::setw(14) << physics::iteration
+      << std::setw(20) << std::scientific << std::setprecision(12)
+      << physics::totaltime << std::endl;
+  }
+
+
+  /**
+   * @brief Periodic file output
+   *
+   * Outputs all scalar reductions as single formatted line to a file. When
+   * creating the file, writes a header to indicate which quantities are
+   * output in which column (because their order and quantity may change
+   * between revisions)
+   * E.g.:
+   * -- >> example output file >> -----------------------------------------
+   * # Scalar reductions:
+   * # 1:iteration 2:time 3:energy 4:mom_x 5:mom_y 6:mom_z
+   * 0  0.0   1.0000000e+03  0.00000000e+00  0.00000000e+00  0.00000000e+00
+   * 10 0.1   1.0000000e+03  0.00000000e+00  0.00000000e+00  0.00000000e+00
+   * 20 0.2   1.0000000e+03  0.00000000e+00  0.00000000e+00  0.00000000e+00
+   * 30 0.3   1.0000000e+03  0.00000000e+00  0.00000000e+00  0.00000000e+00
+   * ...
+   * -- << end output file <<<< -------------------------------------------
+   */
+  void
+  scalar_output(const char * filename = NULL)
+  {
+    static bool first_time = true;
+
+    if (first_time) {
+      // Generate and output the header
+      std::ostringstream oss_header;
+      oss_header
+        << "# Scalar reductions: " <<std::endl
+        << "# 1:iteration 2:time 3:mom_x ";
+
+      // The momentum depends on dimension
+      if(gdimension > 1){
+        oss_header<<"4:mom_y ";
+      }
+      if(gdimension == 3){
+        oss_header<<"5:mom_z ";
+      }
+      oss_header<<std::endl;
+
+      std::ofstream out(filename);
+      out << oss_header.str();
+      out.close();
+
+      first_time = false;
     }
-    if(gdimension == 3){
-      oss_header<<"5:mom_z ";
-    }
-    oss_header<<std::endl;
 
     std::ostringstream oss_data;
-    oss_data << std::setprecision(10);
-    oss_data << physics::iteration <<" "<< physics::totaltime<< " ";
+    oss_data << std::setw(14) << physics::iteration
+      << std::setw(20) << std::scientific << std::setprecision(12)
+      << physics::totaltime;
     for(int i = 0 ; i < gdimension ; ++i){
-      oss_data<<linear_momentum[i]<<" ";
+      oss_data
+        << std::setw(20) << std::scientific << std::setprecision(12)
+        << linear_momentum[i] <<" ";
     }
-    oss_data<<std::endl;
+    oss_data << std::endl;
 
-    // Output to screen 
-    clog(info)<<oss_header.str();
-    clog(info)<<oss_data.str();
+    // Open file in append mode
+    std::ofstream out(filename,std::ios_base::app);
+    out << oss_data.str();
+    out.close();
 
-    // If file output 
-    // Header in file 
-    if(filename != NULL){
-      // Print header if needed, in this case erase content
-      if(header == true){
-        std::ofstream out(filename);
-        out << oss_header.str();
-        out << oss_data.str();
-        out.close(); 
-      }else{
-        // Print the new line of data in this case append
-        std::ofstream out(filename,std::ios_base::app);
-        out << oss_data.str();
-        out.close();
-      }
-    }
-  }
+  } // scalar output
 
 }; // physics
 

--- a/include/physics/default_physics.h
+++ b/include/physics/default_physics.h
@@ -186,6 +186,7 @@ namespace physics{
    * @brief      mu_ij for the artificial viscosity 
    * From CES-Seminar 13/14 - Smoothed Particle Hydrodynamics 
    *
+   * @uses       epsilon:= eta^2 (global parmeter)
    * @param      srch  The source particle
    * @param      nbsh  The neighbor particle
    *
@@ -207,7 +208,7 @@ namespace physics{
     if(dotproduct >= 0.0)
       return result;
     double dist = flecsi::distance(source->getPosition(),nb->getPosition());
-    result = h_ij * dotproduct / (dist*dist + epsilon);
+    result = h_ij * dotproduct / (dist*dist + epsilon*h_ij*h_ij);
     
     mpi_assert(result < 0.0);
     return result; 

--- a/include/physics/specific/fluids_physics.h
+++ b/include/physics/specific/fluids_physics.h
@@ -36,6 +36,7 @@
 
 namespace physics{
 
+  int64_t iteration = 0;
   double dt = 0.000001;
   double K = 3.5;
   double gravity_cste = 9.80665; 

--- a/mpisph/bodies_system.h
+++ b/mpisph/bodies_system.h
@@ -49,15 +49,10 @@ public:
   body_system():totalnbodies_(0L),localnbodies_(0L),macangle_(0.0),
   maxmasscell_(1.0e-40),tree_(nullptr)
   {
-    int rank;
-    MPI_Comm_rank(MPI_COMM_WORLD,&rank); 
     // Display the number of threads in DEBUG mode
-    if(rank==0)
-    {
-      #pragma omp parallel 
-      #pragma omp single 
-      clog(warn)<<"USING OMP THREADS: "<<omp_get_num_threads()<<std::endl;
-    }
+    #pragma omp parallel 
+    #pragma omp single 
+    clog_one(warn)<<"USING OMP THREADS: "<<omp_get_num_threads()<<std::endl;
   };
 
   /**
@@ -201,7 +196,7 @@ public:
     MPI_Allreduce(MPI_IN_PLACE,&smoothinglength_,1,MPI_DOUBLE,MPI_MAX,
         MPI_COMM_WORLD);
 
-    clog(trace)<<"H="<<smoothinglength_<<std::endl;
+    clog_one(trace)<<"H="<<smoothinglength_<<std::endl;
 
     return smoothinglength_;
 
@@ -229,7 +224,7 @@ public:
     MPI_Allreduce(MPI_IN_PLACE,&smoothinglength_,1,MPI_DOUBLE,MPI_MAX,
         MPI_COMM_WORLD);
 
-    clog(trace)<<"H="<<smoothinglength_<<std::endl;
+    clog_one(trace)<<"H="<<smoothinglength_<<std::endl;
 
     tcolorer_.mpi_compute_range(localbodies_,range_,smoothinglength_);
     return range_;
@@ -262,7 +257,7 @@ public:
     // Choose the smoothing length to be the biggest from everyone 
     smoothinglength_ = getSmoothinglength();
 
-    clog(trace)<<"H="<<smoothinglength_<<std::endl;
+    clog_one(trace)<<"H="<<smoothinglength_<<std::endl;
 
     // Then compute the range of the system 
     tcolorer_.mpi_compute_range(localbodies_,range_,smoothinglength_);
@@ -315,11 +310,11 @@ public:
       MPI_COMM_WORLD
       );
 
-    clog(trace)<<rank<<" sub_entities before="; 
+    clog_one(trace)<<rank<<" sub_entities before="; 
     for(auto v: nentities){
-      clog(trace)<<v<<";";
+      clog_one(trace)<<v<<";";
     }
-    clog(trace)<<std::endl;
+    clog_one(trace)<<std::endl;
 #endif
 
     // Exchnage usefull body_holder from my tree to other processes
@@ -343,11 +338,11 @@ public:
       MPI_COMM_WORLD
       );
 
-    clog(trace)<<rank<<" sub_entities after="; 
+    clog_one(trace)<<rank<<" sub_entities after="; 
     for(auto v: nentities){
-      clog(trace)<<v<<";";
+      clog_one(trace)<<v<<";";
     }
-    clog(trace)<<std::endl;
+    clog_one(trace)<<std::endl;
 #endif
     
     tcolorer_.mpi_compute_ghosts(*tree_,bodies_,smoothinglength_/*,range_*/);
@@ -376,7 +371,7 @@ public:
     MPI_Comm_size(MPI_COMM_WORLD,&size);
     MPI_Comm_rank(MPI_COMM_WORLD,&rank);
 
-    clog(trace)<<"FMM: mmass="<<maxmasscell_<<" angle="<<macangle_<<std::endl;
+    clog_one(trace)<<"FMM: mmass="<<maxmasscell_<<" angle="<<macangle_<<std::endl;
 
     // Just consider the local particles in the tree for FMM 
     tree_->update_branches_local(smoothinglength_);

--- a/mpisph/io.h
+++ b/mpisph/io.h
@@ -88,7 +88,7 @@ void inputDataHDF5(
   MPI_Comm_size(MPI_COMM_WORLD,&size); 
   MPI_Comm_rank(MPI_COMM_WORLD,&rank);
 
-  clog(info)<<"Input particles";
+  clog_one(trace)<<"Input particles";
   
   //--------------- OPEN FILE AND READ NUMBER OF PARTICLES -------------------- 
   auto dataFile = H5OpenFile(filename,H5_O_RDONLY
@@ -98,7 +98,7 @@ void inputDataHDF5(
   int val = H5HasStep(dataFile,startiteration);
   
   if(val != 1){
-    clog(error)<<std::endl<<"Step "<<startiteration<<" not found in file "<<
+    clog_one(error)<<std::endl<<"Step "<<startiteration<<" not found in file "<<
         filename<<std::endl<<std::endl;
     MPI_Barrier(MPI_COMM_WORLD);
     MPI_Finalize();
@@ -125,7 +125,7 @@ void inputDataHDF5(
   if(H5_SUCCESS == H5ReadFileAttribInt32(dataFile,"dimension",&dimension)){
     assert(gdimension == dimension);
   }else{
-    clog(error)<<"No dimension value: setting to default 3"<<std::endl;
+    clog_one(error)<<"No dimension value: setting to default 3"<<std::endl;
     dimension = 3;
   }
 
@@ -233,7 +233,7 @@ void inputDataHDF5(
 
   // Internal Energy  
   #ifdef INTERNAL_ENERGY
-  clog(info)<<"Reading internal energy"<<std::endl;
+  clog_one(trace)<<"Reading internal energy"<<std::endl;
   std::fill(dataX,dataX+nparticlesproc,0.);
   H5PartReadDataFloat64(dataFile,"u",dataX);
   for(int64_t i=0; i<nparticlesproc; ++i){
@@ -250,7 +250,7 @@ void inputDataHDF5(
       bodies[i].second.setId(dataInt[i]); 
     }
   }else{
-    clog(info)<<"Setting ID for particles"<<std::endl;
+    clog_one(trace)<<"Setting ID for particles"<<std::endl;
     // Otherwise generate the id 
     int64_t start = (totalnbodies/size)*rank+1;
     for(int64_t i=0; i<nparticlesproc; ++i){
@@ -289,7 +289,7 @@ void inputDataHDF5(
   MPI_Barrier(MPI_COMM_WORLD);
   H5CloseFile(dataFile);
 
-  clog(info)<<".done"<<std::endl;
+  clog_one(trace)<<".done"<<std::endl;
 
 }// inputDataHDF5
 
@@ -309,7 +309,7 @@ void outputDataHDF5(
 
   MPI_Barrier(MPI_COMM_WORLD);
 
-  clog(info)<<"Output particles"<<std::flush;
+  clog_one(trace)<<"Output particles"<<std::flush;
 
   int64_t nparticlesproc = bodies.size();
 
@@ -488,7 +488,7 @@ void outputDataHDF5(
   delete[] bi;
   delete[] bint;
 
-  clog(info)<<".done"<<std::endl;
+  clog_one(trace)<<".done"<<std::endl;
   
 }// outputDataHDF5
 

--- a/mpisph/test/gravitation.cc
+++ b/mpisph/test/gravitation.cc
@@ -32,7 +32,8 @@ TEST(tree_colorer, mpi_qsort){
   double jacobi[9]={};
   double hessian[27]={};
 
-  clog(info)<<"test pSink="<<sinkPosition<<" pSource="<<sourcePosition<<std::endl;
+  clog_one(info) << "test pSink=" << sinkPosition
+                 << " pSource="   << sourcePosition << std::endl;
 
   point_t fc_res(1./(3*sqrt(3)),1./(3*sqrt(3)),1./(3*sqrt(3)));
 
@@ -60,14 +61,17 @@ TEST(tree_colorer, mpi_qsort){
 
   for(int i = 0; i<27; ++i){
     if(i<3){
-      clog(info)<<"fc i="<<i<<": code="<<fc[i]<<" res="<<fc_res[i]<<std::endl;
+      clog_one(info) << "fc i=" << i << ": code=" << fc[i] 
+                     << " res=" << fc_res[i]<<std::endl;
       ASSERT_TRUE(fabs(fc[i]-fc_res[i]) < 1.0e-10);
     }
     if(i<9){
-      clog(info)<<"dfcdr i="<<i<<": code="<<jacobi[i]<<" res="<<jacobi_res[i]<<std::endl;
+      clog_one(info) << "dfcdr i=" << i << ": code=" << jacobi[i] 
+                     << " res=" << jacobi_res[i] << std::endl;
       ASSERT_TRUE(fabs(jacobi[i]-jacobi_res[i]) < 1.0e-10);
     }
-    clog(info)<<"dfcdrdr i="<<i<<": code="<<hessian[i]<<" res="<<hessian_res[i]<<std::endl;
+    clog_one(info) << "dfcdrdr i=" << i << ": code=" << hessian[i]
+                   << " res=" << hessian_res[i] << std::endl;
     ASSERT_TRUE(fabs(hessian[i]-hessian_res[i]) < 1.0e-4);
 
   }
@@ -80,8 +84,9 @@ TEST(tree_colorer, mpi_qsort){
   memset(hessian,0.,sizeof(double)*27);
 
 
-  clog(info)<<std::endl;
-  clog(info)<<"test pSink="<<sinkPosition<<" pSource="<<sourcePosition<<std::endl;
+  clog_one(info) << std::endl;
+  clog_one(info) << "test pSink=" << sinkPosition 
+                 << " pSource=" << sourcePosition << std::endl;
 
 
   point_t fc_res_2 = point_t(-1./(3*sqrt(3)),-1./(3*sqrt(3)),-1./(3*sqrt(3)));
@@ -111,14 +116,17 @@ TEST(tree_colorer, mpi_qsort){
 
   for(int i = 0; i<27; ++i){
     if(i<3){
-      clog(info)<<"fc i="<<i<<": code="<<fc[i]<<" res="<<fc_res_2[i]<<std::endl;
+      clog_one(info) << "fc i=" << i << ": code=" << fc[i]
+                      << " res=" << fc_res_2[i] << std::endl;
       ASSERT_TRUE(fabs(fc[i]-fc_res_2[i]) < 1.0e-4);
     }
     if(i<9){
-      clog(info)<<"dfcdr i="<<i<<": code="<<jacobi[i]<<" res="<<jacobi_res_2[i]<<std::endl;
+      clog_one(info) << "dfcdr i=" << i << ": code=" << jacobi[i] 
+                     << " res=" << jacobi_res_2[i] << std::endl;
       ASSERT_TRUE(fabs(jacobi[i]-jacobi_res_2[i]) < 1.0e-4);
     }
-    clog(info)<<"dfcdrdr i="<<i<<": code="<<hessian[i]<<" res="<<hessian_res_2[i]<<std::endl;
+    clog_one(info) << "dfcdrdr i=" << i << ": code=" << hessian[i]
+                   << " res=" << hessian_res_2[i] << std::endl;
     ASSERT_TRUE(fabs(hessian[i]-hessian_res_2[i]) < 1.0e-4);
   }
 
@@ -131,8 +139,9 @@ TEST(tree_colorer, mpi_qsort){
   memset(hessian,0.,sizeof(double)*27);
 
 
-  clog(info)<<std::endl;
-  clog(info)<<"test pSink="<<sinkPosition<<" pSource="<<sourcePosition<<std::endl;
+  clog_one(info)<< std::endl
+                << "test pSink=" << sinkPosition
+                << " pSource="   << sourcePosition<<std::endl;
 
 
   point_t fc_res_3 = point_t(-1.20281,-1.20281,-1.20281);
@@ -162,14 +171,17 @@ TEST(tree_colorer, mpi_qsort){
 
     for(int i = 0; i<27; ++i){
     if(i<3){
-      clog(info)<<"fc i="<<i<<": code="<<fc[i]<<" res="<<fc_res_3[i]<<std::endl;
+      clog_one(info)<<"fc i="<<i<<": code="<<fc[i]
+                    <<" res="<<fc_res_3[i]<<std::endl;
       ASSERT_TRUE(fabs(fc[i]-fc_res_3[i]) < 1.0e-4);
     }
     if(i<9){
-      clog(info)<<"dfcdr i="<<i<<": code="<<jacobi[i]<<" res="<<jacobi_res_3[i]<<std::endl;
+      clog_one(info)<<"dfcdr i="<<i<<": code="<<jacobi[i]
+                    <<" res="<<jacobi_res_3[i]<<std::endl;
       ASSERT_TRUE(fabs(jacobi[i]-jacobi_res_3[i]) < 1.0e-4);
     }
-    clog(info)<<"dfcdrdr i="<<i<<": code="<<hessian[i]<<" res="<<hessian_res_3[i]<<std::endl;
+    clog_one(info)<<"dfcdrdr i="<<i<<": code="<<hessian[i]
+                  <<" res="<<hessian_res_3[i]<<std::endl;
     ASSERT_TRUE(fabs(hessian[i]-hessian_res_3[i]) < 1.0e-4);
   }
 }

--- a/mpisph/test/mpi_qsort.cc
+++ b/mpisph/test/mpi_qsort.cc
@@ -44,7 +44,7 @@ TEST(tree_colorer, mpi_qsort){
   if(rank == size-1){
     nparticlesperproc = (nparticles-nparticlesperproc*(size-1));
   }
-  clog(info)<<"Generating "<<nparticles<<std::endl;
+  clog_one(info)<<"Generating "<<nparticles<<std::endl;
 
   std::cout<<"Rank "<<rank<<": "<<nparticlesperproc<<" particles"<<std::endl;
 

--- a/mpisph/tree_colorer.h
+++ b/mpisph/tree_colorer.h
@@ -191,13 +191,13 @@ public:
 
     if(neighbors_count.size() > 1){
       #ifdef OUTPUT_TREE_INFO
-      clog(trace)<<"Weight function"<<std::endl;
+      clog_one(trace)<<"Weight function"<<std::endl;
       #endif
       generate_splitters_weight(splitters,rbodies,totalnbodies,neighbors_count); 
     }else{
       generate_splitters_samples(splitters,rbodies,totalnbodies);
       #ifdef OUTPUT_TREE_INFO
-      clog(trace)<<"Normal function"<<std::endl;
+      clog_one(trace)<<"Normal function"<<std::endl;
       #endif
     }
 
@@ -248,11 +248,11 @@ public:
     MPI_Allgather(&mybodies,1,MPI_INT,&totalprocbodies[0],1,MPI_INT,
       MPI_COMM_WORLD);
     #ifdef OUTPUT_TREE_INFO
-    clog(trace)<<"Repartition: ";
+    clog_one(trace)<<"Repartition: ";
     for(auto num: totalprocbodies)
-      clog(trace)<<num<<";";
+      clog_one(trace)<<num<<";";
     double end = omp_get_wtime();
-    clog(trace)<< end-start << "s "<<std::endl;
+    clog_one(trace)<< end-start << "s "<<std::endl;
     #endif
 #endif // OUTPUT
   } // mpi_qsort
@@ -289,7 +289,7 @@ public:
     MPI_Barrier(MPI_COMM_WORLD);
     double start = omp_get_wtime();
     #ifdef OUTPUT_TREE_INFO
-    clog(trace)<<"Branches repartition" << std::flush;
+    clog_one(trace)<<"Branches repartition" << std::flush;
     #endif 
 #endif
 
@@ -327,11 +327,11 @@ public:
     );
 
     #ifdef OUTPUT_TREE_INFO
-    clog(trace)<<"Packets with ncrit="<<criterion_branches<<" = ";
+    clog_one(trace)<<"Packets with ncrit="<<criterion_branches<<" = ";
     for(auto v: count_search_branches){
-      clog(trace)<<v<<";";
+      clog_one(trace)<<v<<";";
     }
-    clog(trace)t<<std::endl;
+    clog_one(trace)t<<std::endl;
     }
     #endif 
 
@@ -426,7 +426,7 @@ public:
 #ifdef OUTPUT_TREE_INFO
     MPI_Barrier(MPI_COMM_WORLD);
     double end = omp_get_wtime();
-    clog(trace)<<".done "<< end-start << "s" <<std::endl;
+    clog_one(trace)<<".done "<< end-start << "s" <<std::endl;
 #endif
 
   }
@@ -447,7 +447,7 @@ void mpi_refresh_ghosts(
   
 #ifdef OUTPUT_TREE_INFO
     MPI_Barrier(MPI_COMM_WORLD);
-    clog(trace)<<"Refresh Ghosts" << std::flush;
+    clog_one(trace)<<"Refresh Ghosts" << std::flush;
     double start = omp_get_wtime(); 
 #endif 
    // Refresh the sendbodies with new data
@@ -492,7 +492,7 @@ void mpi_refresh_ghosts(
 #ifdef OUTPUT_TREE_INFO
     MPI_Barrier(MPI_COMM_WORLD);
     double end = omp_get_wtime();
-    clog(trace)".done "<< end-start << "s "<< std::endl << std::flush;
+    clog_one(trace)".done "<< end-start << "s "<< std::endl << std::flush;
 
 #endif
   }
@@ -528,7 +528,7 @@ void mpi_refresh_ghosts(
 
 #ifdef OUTPUT_TREE_INFO
     MPI_Barrier(MPI_COMM_WORLD);
-    clog(trace)<<"Compute Ghosts" << std::flush;
+    clog_one(trace)<<"Compute Ghosts" << std::flush;
     double start = omp_get_wtime();
 #endif
 
@@ -665,7 +665,7 @@ void mpi_refresh_ghosts(
 #ifdef OUTPUT_TREE_INFO
     MPI_Barrier(MPI_COMM_WORLD);
     double end = omp_get_wtime();
-    clog(trace)<<".done "<< end-start << "s"<<std::endl;
+    clog_one(trace)<<".done "<< end-start << "s"<<std::endl;
 #endif
   }
 
@@ -715,7 +715,7 @@ void mpi_refresh_ghosts(
     }
 
 #ifdef OUTPUT_TREE_INFO
-    clog(trace)<<"boundaries: "<< minposition << maxposition << std::endl;
+    clog_one(trace)<<"boundaries: "<< minposition << maxposition << std::endl;
 #endif 
 
     range[0] = minposition;
@@ -739,7 +739,7 @@ void mpi_refresh_ghosts(
       &totalneighbors,1,MPI_INT64_T,MPI_SUM,MPI_COMM_WORLD);
 
     #ifdef OUTPUT_TREE_INFO
-    clog(trace)<<"Total number of neighbors = "<< totalneighbors << std::endl;
+    clog_one(trace)<<"Total number of neighbors = "<< totalneighbors << std::endl;
     #endif
 
     // Create a vector for the samplers 

--- a/mpisph/tree_fmm.h
+++ b/mpisph/tree_fmm.h
@@ -230,7 +230,7 @@ public:
 
     assert(send_particles_count_[rank] == 0);
     MPI_Barrier(MPI_COMM_WORLD);
-    clog(trace)<<"mpi_compute_fmm in "<<omp_get_wtime()-time<<
+    clog_one(trace)<<"mpi_compute_fmm in "<<omp_get_wtime()-time<<
       "s"<<std::endl<<std::flush;
   }
 
@@ -395,10 +395,10 @@ public:
     MPI_Allgatherv(&vcells[0],nrecvCOM_[rank],MPI_BYTE,
       &recvCOM_[0],&nrecvCOM_[0],&noffsets[0],MPI_BYTE,MPI_COMM_WORLD);
     
-    clog(trace)<<"FMM COM = ";
+    clog_one(trace)<<"FMM COM = ";
     for(auto v: nrecvCOM_)
-     clog(trace)<<v/sizeof(mpi_cell_t)<<";";
-    clog(trace)<<std::endl;
+     clog_one(trace)<<v/sizeof(mpi_cell_t)<<";";
+    clog_one(trace)<<std::endl;
 
     // Check if mine are in the right order 
     #pragma omp parallel for 
@@ -408,7 +408,7 @@ public:
     }// for
 
     MPI_Barrier(MPI_COMM_WORLD);
-    clog(trace)<<"mpi_exchange_cells in "<<omp_get_wtime()-time<<
+    clog_one(trace)<<"mpi_exchange_cells in "<<omp_get_wtime()-time<<
       "s"<<std::endl<<std::flush;
   } // mpi_exchange_cells
 
@@ -518,7 +518,7 @@ public:
       assert(recvcells[i].ninterations == totalnbodies);
     }
     MPI_Barrier(MPI_COMM_WORLD);
-    clog(trace)<<"mpi_gather_cells in "<<omp_get_wtime()-time<<
+    clog_one(trace)<<"mpi_gather_cells in "<<omp_get_wtime()-time<<
       "s"<<std::endl<<std::flush;
   } // mpi_gather_cells
 


### PR DESCRIPTION
Apparently, we should be using 'clog_one' for single-rank output, with the output rank set after MPI initialization with the clog_set_output_rank(0) macro. I have corrected this everywhere (along with some other minor fixes here and there).