### PR TITLE
introducing global parameters and parfile

### DIFF
--- a/app/bns_3D/main_driver.cc
+++ b/app/bns_3D/main_driver.cc
@@ -95,7 +95,7 @@ mpi_init_task(int startiteration = 0, int maxiter = 1000, double macangle = 0){
 //
 
   bs.setMacangle(macangle);
-  bs.setMaxmasscell(10e-5);
+  bs.setMaxmasscell(10e-5); // TODO: hardcoded value, turn to a parameter
 
   clog_one(trace)<<"MacAngle="<<macangle<<std::endl;
 
@@ -141,7 +141,7 @@ mpi_init_task(int startiteration = 0, int maxiter = 1000, double macangle = 0){
         body * src = source->getBody();
         point_t pos = src->getPosition();
         for(size_t i = 0 ; i < gdimension ; ++i){
-          if(pos[i] > 10){
+          if(pos[i] > 10){ // TODO: 10 is hardcoded, turn to a parameter
             pos[i] = 10;
             src->setVelocity(point_t{});
           }

--- a/app/bns_3D/main_driver.cc
+++ b/app/bns_3D/main_driver.cc
@@ -37,6 +37,7 @@
 #include "flecsi/data/data_client.h"
 #include "flecsi/data/data.h"
 
+#include "params.h"
 #include "bodies_system.h"
 #include "default_physics.h"
 #include "BNS_physics.h"
@@ -87,7 +88,7 @@ mpi_init_task(int startiteration = 0, int maxiter = 1000, double macangle = 0){
 
 // Setting physics data 
   physics::dt = 1.0e-8;
-  physics::gamma = 2.0;
+  //physics::gamma = 2.0;  // converted to a parameter (poly_gamma)
   physics::A = 0.6366197723675814;
   // Load angular momentum from data file 
   physics::angular_moment = bs.get_attribute<double>("hdf5_bns_3D.h5part", 

--- a/app/bwd/main_driver.cc
+++ b/app/bwd/main_driver.cc
@@ -37,6 +37,7 @@
 #include "flecsi/data/data_client.h"
 #include "flecsi/data/data.h"
 
+#include "params.h"
 #include <bodies_system.h>
 
 #include "default_physics.h"
@@ -67,7 +68,7 @@ mpi_init_task(int startiteration){
   physics::stop_boundaries = true;
   physics::min_boundary = {0.1};
   physics::max_boundary = {1.0};
-  physics::gamma = 5./3.;
+  ///physics::gamma = 5./3.; // converted to a parameter (poly_gamma)
   physics::epsilon = 0.01;
 
   body_system<double,gdimension> bs;

--- a/app/bwd/main_driver.cc
+++ b/app/bwd/main_driver.cc
@@ -63,13 +63,13 @@ mpi_init_task(int startiteration){
 
   // Init if default values are not ok
   physics::dt = 1.0e-10;
-  physics::alpha = 1; 
-  physics::beta = 2; 
-  //physics::stop_boundaries = true; // converted to a parameter
+  ///physics::alpha = 1; // converted to a parameter: sph_viscosity_alpha
+  ///physics::beta = 2;  // converted to sph_viscosity_beta
+  ///physics::stop_boundaries = true; // converted to a parameter
   physics::min_boundary = {0.1};
   physics::max_boundary = {1.0};
   ///physics::gamma = 5./3.; // converted to a parameter (poly_gamma)
-  physics::epsilon = 0.01;
+  ///physics::epsilon = 0.01; // converted to sph_viscosity_epsilon
 
   body_system<double,gdimension> bs;
   bs.read_bodies("bwd_id.h5part",startiteration);

--- a/app/bwd/main_driver.cc
+++ b/app/bwd/main_driver.cc
@@ -65,7 +65,7 @@ mpi_init_task(int startiteration){
   physics::dt = 1.0e-10;
   physics::alpha = 1; 
   physics::beta = 2; 
-  physics::stop_boundaries = true;
+  //physics::stop_boundaries = true; // converted to a parameter
   physics::min_boundary = {0.1};
   physics::max_boundary = {1.0};
   ///physics::gamma = 5./3.; // converted to a parameter (poly_gamma)

--- a/app/fluid_2D/generator/main.cc
+++ b/app/fluid_2D/generator/main.cc
@@ -13,8 +13,8 @@
 
 enum type {WALL=1, SIMPLE=0};
 
-const double rest_density = 998.29;
-const double m_ = 0.02;
+const double rest_density = 998.29;         // initial density
+const double m_ = 0.02;                     // mass of an individual particle
 const double rho_ = rest_density;
 const double smoothing_length = 0.0457;
 const double ldistance = smoothing_length;  // Distance between the particles 

--- a/app/fluid_2D/main_driver.cc
+++ b/app/fluid_2D/main_driver.cc
@@ -158,7 +158,7 @@ driver(int argc,  char * argv[]){
 } // driver
 
 
-} // namespace
-} // namespace
+} // namespace execution
+} // namespace flecsi
 
 

--- a/app/noh/generator/main.cc
+++ b/app/noh/generator/main.cc
@@ -7,7 +7,7 @@
 /*
  * Noh Collapse test
  * -----------------
- * The tet is initialized as disk / sphere of particles with homogeneous density, 
+ * The test is initialized as a disk / sphere of particles with homogeneous density, 
  * vanishingly small pressure, and inward velocity. As particles move inwards, they
  * pile up at the center at forming a region with constant density that is dependent 
  * on gamma and the dimensionality of the problem. 

--- a/app/noh/generator/main.cc
+++ b/app/noh/generator/main.cc
@@ -23,7 +23,7 @@
 #include <algorithm>
 #include <cassert>
 
-///#define poly_gamma 5./3. // Gamma for ideal gas eos
+#define poly_gamma 5./3. // Gamma for ideal gas eos
 #include "params.h"
 #include "hdf5ParticleIO.h"
 #include "kernels.h"

--- a/app/noh/generator/main.cc
+++ b/app/noh/generator/main.cc
@@ -23,12 +23,13 @@
 #include <algorithm>
 #include <cassert>
 
+///#define poly_gamma 5./3. // Gamma for ideal gas eos
+#include "params.h"
 #include "hdf5ParticleIO.h"
 #include "kernels.h"
 
     
 const double ldistance = 0.001;                     // Distance between the particles 
-const double localgamma = 5./3.;                    // Gamma for ideal gas eos
 const double rho_in = 1;                            // Initial density 
 const double P_in = 1.0e-6;                         // Initial pressure
 const double smoothing_length = 2.0*ldistance;      
@@ -47,6 +48,7 @@ bool in_radius(
 
 
 int main(int argc, char * argv[]){
+  using namespace param;
 
   int64_t sparticles = 100;         // Default number of particles
 
@@ -194,7 +196,7 @@ int main(int argc, char * argv[]){
     m[part] = m_in;
 
     // Assign particle internal energy 
-    u[part] = P[part]/(localgamma-1.)/rho[part];
+    u[part] = P[part]/(poly_gamma-1.)/rho[part];
 
     // Assign particle smoothing length
     h[part] = smoothing_length;

--- a/app/noh/generator/main.cc
+++ b/app/noh/generator/main.cc
@@ -7,14 +7,14 @@
 /*
  * Noh Collapse test
  * -----------------
- * The test is initialized as a disk / sphere of particles with homogeneous density, 
+ * The test is initialized as a disk / sphere of particles with homogeneous density,
  * vanishingly small pressure, and inward velocity. As particles move inwards, they
- * pile up at the center at forming a region with constant density that is dependent 
- * on gamma and the dimensionality of the problem. 
+ * pile up at the center at forming a region with constant density that is dependent
+ * on gamma and the dimensionality of the problem.
  * A standing shock front forms that moves outwards as more particles are piling up.
  *
  * For an analytic solution, see the code noh.f in /src/tools
- * For more information, see: 
+ * For more information, see:
  * Liska & Wendroff, 2003, SIAM J. Sci. Comput. 25, 995, Section 4.5
 */
 
@@ -28,12 +28,42 @@
 #include "hdf5ParticleIO.h"
 #include "kernels.h"
 
-    
-const double ldistance = 0.001;                     // Distance between the particles 
-const double rho_in = 1;                            // Initial density 
-const double P_in = 1.0e-6;                         // Initial pressure
-const double smoothing_length = 2.0*ldistance;      
-const char* fileprefix = "hdf5_noh";                // Output file prefix
+//
+// help message
+//
+void print_usage() {
+  clog_one(warn)
+      << "Initial data generator for the Noh collapse test" << std::endl
+      << "Usage: ./noh_generator <parameter-file.par>"      << std::endl;
+}
+
+
+//
+// derived parameters
+//
+static double ldistance;      // Distance between the particles
+static double rho_in;         // Initial density
+static double P_in;           // Initial pressure
+static double smoothing_length;
+static std::string initial_data_file; // = initial_data_prefix + ".h5part"
+
+void set_derived_params() {
+  using namespace param;
+
+  // total number of particles
+  SET_PARAM(nparticles, sqrt_nparticles*sqrt_nparticles);
+
+  ldistance = 0.001;  // Distance between the particles (TODO: sph_separation)
+  rho_in = 1;                                       //  (TODO: rho_intial)
+  P_in = 1.0e-6;                                    //  (TODO: pressure_initial)
+  smoothing_length = 2.*ldistance;                  //  (TODO: sph_smoothing_length)
+
+  // file to be generated
+  std::ostringstream oss;
+  oss << initial_data_prefix << ".h5part";
+  initial_data_file = oss.str();
+
+}
 
 
 // Is particle with x,y coordinates within a disk (center located at x0,y0) with radius r?
@@ -41,7 +71,7 @@ bool in_radius(
     double x,
     double y,
     double x0,
-    double y0, 
+    double y0,
     double r) {
     return (x-x0)*(x-x0)+(y-y0)*(y-y0) < r*r;
 }
@@ -50,44 +80,39 @@ bool in_radius(
 int main(int argc, char * argv[]){
   using namespace param;
 
-  int64_t sparticles = 100;         // Default number of particles
-
-  int rank, size; 
-  int provided; 
-
+  int rank, size, provided;
   MPI_Init_thread(&argc,&argv,MPI_THREAD_MULTIPLE,&provided);
-  assert(provided>=MPI_THREAD_MULTIPLE); 
+  assert(provided>=MPI_THREAD_MULTIPLE);
   MPI_Comm_rank(MPI_COMM_WORLD,&rank);
   MPI_Comm_size(MPI_COMM_WORLD,&size);
   clog_set_output_rank(0);
 
+  // check options list: exactly one command-line argument is accepted
   if (argc != 2) {
-    clog_one(warn) << "WARNING: number of particles not specitifed!" << std::endl
-                   << "Usage: ./noh_generator [sqrt {nParticles}]"   << std::endl
-                   << "Generating default number of particles: "     
-                   << sparticles<<"*"<<sparticles << " => "
-                   << sparticles*sparticles << std::endl;
+    clog_one(error) << "ERROR: parameter file not specified!" << std::endl;
+    print_usage();
+    MPI_Finalize();
+    exit(0);
   }
-  else sparticles = atoll(argv[1]);
 
+  // set simulation parameters
+  param::mpi_read_params(argv[1]);
+  set_derived_params();
 
-  // Total number of initialized particles
-  int64_t nparticles = sparticles*sparticles;
-
-  // Radius of the disk given the number of particles 
-  double radius = (ldistance*(sparticles - 1))/2.0; 
+  // Radius of the disk given the number of particles
+  double radius = (ldistance*(sqrt_nparticles - 1))/2.0;
 
   // Center of disk
-  double x_c = (sparticles - 1)*ldistance/2.0;
+  double x_c = (sqrt_nparticles - 1)*ldistance/2.0;
   double y_c = x_c;
 
   // Particle mass given the initial density and number of particles
-  double m_in = rho_in * radius * radius * 4.0 / nparticles; 
+  double m_in = rho_in * radius * radius * 4.0 / nparticles;
 
   clog_one(info) << "Sphere: r=" << radius << std::endl
                  << "origin: pos=["<<x_c<<";"<<y_c<<"]" << std::endl
-                 << "Generating "  << nparticles 
-                 << " particles (="<< sparticles<<"^2) " << std::endl;
+                 << "Generating "  << nparticles
+                 << " particles (="<< sqrt_nparticles<<"^2) " << std::endl;
 
 
   // Start on  0 0
@@ -97,7 +122,7 @@ int main(int argc, char * argv[]){
   double maxxposition = x_c + radius;
   double maxyposition = y_c + radius;
 
-  // Particle positions   
+  // Particle positions
   double* x = new double[nparticles]();
   double* y = new double[nparticles]();
   double* z = new double[nparticles]();
@@ -107,7 +132,7 @@ int main(int argc, char * argv[]){
   double* vy = new double[nparticles]();
   double* vz = new double[nparticles]();
 
-  // Particle accelerations 
+  // Particle accelerations
   double* ax = new double[nparticles]();
   double* ay = new double[nparticles]();
   double* az = new double[nparticles]();
@@ -133,31 +158,31 @@ int main(int argc, char * argv[]){
 
   // Timestep
   double* dt = new double[nparticles]();
-  
-  // ID of first particle 
+
+  // ID of first particle
   int64_t posid = 0;
 
 
-  // Header data 
-  // the number of particles = nparticles 
-  // The value for constant timestep 
-  double timestep = 0.001;
-  int dimension = 2;
-  
-  clog_one(info) << "top_X=" << x_topproc << " top_Y="  << y_topproc    << std::endl 
+  // Header data
+  // the number of particles = nparticles
+  // The value for constant timestep
+  double timestep = 0.001;  // TODO: replace with parameter initial_dt
+  int dimension = 2;        // TODO: use global dimension parameter
+
+  clog_one(info) << "top_X=" << x_topproc << " top_Y="  << y_topproc    << std::endl
                  << "maxX=" << maxxposition << " maxY=" << maxyposition << std::endl;
 
-  double xposition = x_topproc; 
+  double xposition = x_topproc;
   double yposition = y_topproc;
   int64_t tparticles = 0;
 
 
-  // Loop over all particles and assign position, velocity etc. 
-  for (int64_t part = 0; part < nparticles; ++part) {    
+  // Loop over all particles and assign position, velocity etc.
+  for (int64_t part = 0; part < nparticles; ++part) {
 
-    // Checks if particle is in the disk and creates position coordinates 
+    // Checks if particle is in the disk and creates position coordinates
     while (!in_radius(xposition, yposition, x_c, y_c, radius)) {
-      xposition += ldistance; 
+      xposition += ldistance;
       if (xposition > maxxposition) {
         if (yposition > maxyposition) {break;}
         xposition  = x_topproc;
@@ -173,7 +198,7 @@ int main(int argc, char * argv[]){
     // Assign particle position
     x[part] = xposition;
     y[part] = yposition;
-         
+
     xposition += ldistance;
     if (xposition > maxxposition) {
       if (yposition > maxyposition) {break;}
@@ -184,10 +209,10 @@ int main(int argc, char * argv[]){
     // Assign particle pressure
     P[part] = P_in;
 
-    // Assign particle density 
-    rho[part] = rho_in; 
+    // Assign particle density
+    rho[part] = rho_in;
 
-    // Assign particle accelerations 
+    // Assign particle accelerations
     ax[part] = 0.0;
     ay[part] = 0.0;
     az[part] = 0.0;
@@ -195,7 +220,7 @@ int main(int argc, char * argv[]){
     // Assign particle mass
     m[part] = m_in;
 
-    // Assign particle internal energy 
+    // Assign particle internal energy
     u[part] = P[part]/(poly_gamma-1.)/rho[part];
 
     // Assign particle smoothing length
@@ -205,28 +230,25 @@ int main(int argc, char * argv[]){
     id[part] = posid++;
 
     // Assign particle inward pointing velocity with absolute value 0.1
-    double A = sqrt((x[part]-x_c)*(x[part]-x_c) + (y[part]-y_c)*(y[part]-y_c)); 
+    double A = sqrt((x[part]-x_c)*(x[part]-x_c) + (y[part]-y_c)*(y[part]-y_c));
     if (A <= 0.0) {
       vx[part] = 0.0;
       vy[part] = 0.0;
     }
     else {
       vx[part] = -(x[part]-x_c) * 0.1 / A;
-      vy[part] = -(y[part]-y_c) * 0.1 / A;  
+      vy[part] = -(y[part]-y_c) * 0.1 / A;
     }
   }
 
-  clog_one(info) << "Actual number of particles inside the sphere: " 
+  clog_one(info) << "Actual number of particles inside the sphere: "
                  << tparticles << std::endl;
 
-  char filename[128];
-  sprintf(filename,"%s.h5part",fileprefix);
+  // remove the previous file
+  remove(initial_data_file.c_str());
 
-  // Remove the previous file 
-  remove(filename); 
-
-  Flecsi_Sim_IO::HDF5ParticleIO testDataSet; 
-  testDataSet.createDataset(filename,MPI_COMM_WORLD);
+  Flecsi_Sim_IO::HDF5ParticleIO testDataSet;
+  testDataSet.createDataset(initial_data_file.c_str(),MPI_COMM_WORLD);
 
   // add the global attributes
   testDataSet.writeDatasetAttribute("nparticles","int64_t",tparticles);
@@ -274,7 +296,7 @@ int main(int argc, char * argv[]){
   _d1.createVariable("h",Flecsi_Sim_IO::point,"double",tparticles,h);
   _d2.createVariable("rho",Flecsi_Sim_IO::point,"double",tparticles,rho);
   _d3.createVariable("u",Flecsi_Sim_IO::point,"double",tparticles,u);
-  
+
   testDataSet.vars.push_back(_d1);
   testDataSet.vars.push_back(_d2);
   testDataSet.vars.push_back(_d3);
@@ -284,15 +306,15 @@ int main(int argc, char * argv[]){
   _d1.createVariable("P",Flecsi_Sim_IO::point,"double",tparticles,P);
   _d2.createVariable("m",Flecsi_Sim_IO::point,"double",tparticles,m);
   _d3.createVariable("id",Flecsi_Sim_IO::point,"int64_t",tparticles,id);
-  
+
   testDataSet.vars.push_back(_d1);
   testDataSet.vars.push_back(_d2);
   testDataSet.vars.push_back(_d3);
 
   testDataSet.writeVariables();
 
-  testDataSet.closeFile(); 
-  
+  testDataSet.closeFile();
+
   delete[] x;
   delete[] y;
   delete[] z;
@@ -309,7 +331,7 @@ int main(int argc, char * argv[]){
   delete[] m;
   delete[] id;
   delete[] dt;
- 
+
   MPI_Finalize();
   return 0;
 }

--- a/app/noh/main_driver.cc
+++ b/app/noh/main_driver.cc
@@ -43,6 +43,8 @@
 #include "default_physics.h"
 #include "analysis.h"
 
+#define OUTPUT_ANALYSIS
+
 static std::string initial_data_file;  // = initial_data_prefix  + ".h5part"
 static std::string output_h5data_file; // = output_h5data_prefix + ".h5part"
 

--- a/app/noh/main_driver.cc
+++ b/app/noh/main_driver.cc
@@ -37,7 +37,7 @@
 #include "flecsi/data/data_client.h"
 #include "flecsi/data/data.h"
 
-#define poly_gamma 5./3.
+// #define poly_gamma 5./3.
 #include "params.h"
 #include "bodies_system.h"
 #include "default_physics.h"

--- a/app/noh/main_driver.cc
+++ b/app/noh/main_driver.cc
@@ -37,6 +37,7 @@
 #include "flecsi/data/data_client.h"
 #include "flecsi/data/data.h"
 
+#define poly_gamma 5./3.
 #include "params.h"
 #include "bodies_system.h"
 #include "default_physics.h"

--- a/app/noh/main_driver.cc
+++ b/app/noh/main_driver.cc
@@ -4,7 +4,7 @@
  *~--------------------------------------------------------------------------~*/
 
  /*~--------------------------------------------------------------------------~*
- * 
+ *
  * /@@@@@@@@  @@           @@@@@@   @@@@@@@@ @@@@@@@  @@      @@
  * /@@/////  /@@          @@////@@ @@////// /@@////@@/@@     /@@
  * /@@       /@@  @@@@@  @@    // /@@       /@@   /@@/@@     /@@
@@ -12,7 +12,7 @@
  * /@@////   /@@/@@@@@@@/@@       ////////@@/@@////  /@@//////@@
  * /@@       /@@/@@//// //@@    @@       /@@/@@      /@@     /@@
  * /@@       @@@//@@@@@@ //@@@@@@  @@@@@@@@ /@@      /@@     /@@
- * //       ///  //////   //////  ////////  //       //      //  
+ * //       ///  //////   //////  ////////  //       //      //
  *
  *~--------------------------------------------------------------------------~*/
 
@@ -20,9 +20,9 @@
  * @file main_driver.cc
  * @author Julien Loiseau
  * @date April 2017
- * @brief Specialization and Main driver used in FleCSI. 
- * The Specialization Driver is normally used to register data and the main 
- * code is in the Driver.  
+ * @brief Specialization and Main driver used in FleCSI.
+ * The Specialization Driver is normally used to register data and the main
+ * code is in the Driver.
  */
 
 #include <iostream>
@@ -43,123 +43,152 @@
 #include "default_physics.h"
 #include "analysis.h"
 
+static std::string initial_data_file;  // = initial_data_prefix  + ".h5part"
+static std::string output_h5data_file; // = output_h5data_prefix + ".h5part"
+
+void set_derived_params() {
+  using namespace param;
+
+  // filenames (this will change for multiple files output)
+  std::ostringstream oss;
+  oss << initial_data_prefix << ".h5part";
+  initial_data_file = oss.str();
+  oss << output_h5data_prefix << ".h5part";
+  output_h5data_file = oss.str();
+
+  // iteration and time
+  physics::iteration = initial_iteration;
+  physics::totaltime = initial_time;
+  physics::dt = initial_dt; // TODO: use particle separation and Courant factor
+}
+
 namespace flecsi{
 namespace execution{
 
 void
-mpi_init_task(int startiteration){
+mpi_init_task(const char * parameter_file){
+  using namespace param;
+
   int rank;
   int size;
   MPI_Comm_size(MPI_COMM_WORLD,&size);
   MPI_Comm_rank(MPI_COMM_WORLD,&rank);
   clog_set_output_rank(0);
-  
-  int totaliters   = 500;
-  int iteroutput   = 10;
-  double totaltime = 0.0;
-  double maxtime   = 10.0;
-  physics::iteration = startiteration; 
 
-  // Init if default values are not ok
-  physics::dt = 0.001;
-  physics::alpha = 1; 
-  physics::beta  = 2; 
-  ///physics::gamma = 5./3.; // converted to a parameter poly_gamma
-  physics::epsilon = 0.01;
+  // set simulation parameters
+  param::mpi_read_params(parameter_file);
+  set_derived_params();
 
+  // remove output file
+  remove(output_h5data_file.c_str());
+
+  // read input file
   body_system<double,gdimension> bs;
-  bs.read_bodies("hdf5_noh.h5part",startiteration);
-
-  remove("output_noh.h5part"); 
+  bs.read_bodies(initial_data_file.c_str(),initial_iteration);
 
 #ifdef OUTPUT
-  bs.write_bodies("output_noh",physics::iteration);
+  bs.write_bodies(output_h5data_prefix,physics::iteration);
 #endif
 
-  ++physics::iteration; 
-  do { 
+  ++physics::iteration;
+  do {
     analysis::screen_output();
     MPI_Barrier(MPI_COMM_WORLD);
 
-    // Compute and prepare the tree for this iteration 
-    // - Compute the Max smoothing length 
+    // Compute and prepare the tree for this iteration
+    // - Compute the Max smoothing length
     // - Compute the range of the system using the smoothinglength
-    // - Cmopute the keys 
-    // - Distributed qsort and sharing 
+    // - Cmopute the keys
+    // - Distributed qsort and sharing
     // - Generate and feed the tree
-    // - Exchange branches for smoothing length 
-    // - Compute and exchange ghosts in real smoothing length 
+    // - Exchange branches for smoothing length
+    // - Compute and exchange ghosts in real smoothing length
     bs.update_iteration();
-   
+
     // Do the Noh physics
-    clog_one(trace) << "compute_density_pressure_soundspeed" << std::flush; 
+    clog_one(trace) << "compute_density_pressure_soundspeed" << std::flush;
     bs.apply_in_smoothinglength(physics::compute_density_pressure_soundspeed);
     clog_one(trace) << ".done" << std::endl;
-    
-    // Refresh the neighbors within the smoothing length 
-    bs.update_neighbors(); 
 
-    clog_one(trace) << "Hydro acceleration" << std::flush; 
+    // Refresh the neighbors within the smoothing length
+    bs.update_neighbors();
+
+    clog_one(trace) << "Hydro acceleration" << std::flush;
     bs.apply_in_smoothinglength(physics::compute_hydro_acceleration);
     clog_one(trace) << ".done" << std::endl;
- 
-    clog_one(trace) << "Internalenergy" << std::flush; 
+
+    clog_one(trace) << "Internalenergy" << std::flush;
     bs.apply_in_smoothinglength(physics::compute_dudt);
-    clog_one(trace) << ".done" << std::endl; 
-   
-    if (physics::iteration == 1){ 
-      clog_one(trace) << "leapfrog" << std::flush; 
+    clog_one(trace) << ".done" << std::endl;
+
+    if (physics::iteration == 1){
+      clog_one(trace) << "leapfrog" << std::flush;
       bs.apply_all(physics::leapfrog_integration_first_step);
       clog_one(trace) << ".done" << std::endl;
     }
     else{
-      clog_one(trace) << "leapfrog" << std::flush; 
+      clog_one(trace) << "leapfrog" << std::flush;
       bs.apply_all(physics::leapfrog_integration);
       clog_one(trace) << ".done" << std::endl;
     }
 
-    clog_one(trace) <<"dudt integration"<<std::flush; 
+    clog_one(trace) <<"dudt integration"<<std::flush;
     bs.apply_all(physics::dudt_integration);
     clog_one(trace) << ".done" << std::endl;
-   
 
-    physics::totaltime += physics::dt;
+#ifdef OUTPUT_ANALYSIS
+    // Compute the analysis values based on physics
+    bs.get_all(analysis::compute_lin_momentum);
+    bs.get_all(analysis::compute_total_mass);
+    // Only add the header in the first iteration
+    analysis::scalar_output("scalar_reductions.dat");
+#endif
 
 #ifdef OUTPUT
-// TODO: add scalar output
-    if (physics::iteration % iteroutput == 0){ 
-      bs.write_bodies("output_noh",physics::iteration/iteroutput);
+    if(out_h5data_every > 0 && physics::iteration % out_h5data_every == 0){
+      bs.write_bodies(output_h5data_prefix,physics::iteration/out_h5data_every);
     }
+    MPI_Barrier(MPI_COMM_WORLD);
 #endif
     ++physics::iteration;
-    
-  }while(physics::iteration<totaliters);
-}
+    physics::totaltime += physics::dt;
+
+  } while(physics::iteration <= final_iteration);
+} // mpi_init_task
 
 
 flecsi_register_mpi_task(mpi_init_task);
 
-
 void 
-specialization_tlt_init(int argc, char * argv[]){  
-  // Default start at iteration 0
-  int startiteration = 0;
-  if (argc == 2){
-    startiteration = atoi(argv[1]);
-  }
+usage() {
+  clog_one(warn) << "Usage: ./noh <parameter-file.par>"
+                 << std::endl << std::flush;
+}
+
+
+void
+specialization_tlt_init(int argc, char * argv[]){
   clog_one(trace) << "In user specialization_driver" << std::endl;
-  flecsi_execute_mpi_task(mpi_init_task,startiteration); 
+
+  // check options list: exactly one option is allowed
+  if (argc != 2) {
+    clog_one(error) << "ERROR: parameter file not specified!" << std::endl;
+    usage();
+    return;
+  }
+
+  flecsi_execute_mpi_task(mpi_init_task, argv[1]);
+
 } // specialization driver
 
 
-
-void 
+void
 driver(int argc,  char * argv[]){
   clog_one(trace) << "In user driver" << std::endl;
 } // driver
 
 
-} // namespace
-} // namespace
+} // namespace execution
+} // namespace flecsi
 
 

--- a/app/noh/main_driver.cc
+++ b/app/noh/main_driver.cc
@@ -37,6 +37,7 @@
 #include "flecsi/data/data_client.h"
 #include "flecsi/data/data.h"
 
+#include "params.h"
 #include "bodies_system.h"
 #include "default_physics.h"
 #include "analysis.h"
@@ -62,7 +63,7 @@ mpi_init_task(int startiteration){
   physics::dt = 0.001;
   physics::alpha = 1; 
   physics::beta  = 2; 
-  physics::gamma = 5./3.;
+  ///physics::gamma = 5./3.; // converted to a parameter poly_gamma
   physics::epsilon = 0.01;
 
   body_system<double,gdimension> bs;

--- a/app/noh/test/noh_sqn100.par
+++ b/app/noh/test/noh_sqn100.par
@@ -1,0 +1,20 @@
+#
+# Noh collapse, rebounce & standing shock test
+#
+# initial data
+  initial_data_prefix = "noh_sqn100"
+  sqrt_nparticles = 100   # sqrt of the total number of particles
+  ### poly_gamma = 1.6666667  # polytropic index
+  rho_initial = 1.0
+  pressure_initial = 1.0e-6
+  sph_eta = 1.5
+
+# evolution parameters:
+  initial_dt = 0.001      # TODO: better use Courant factor X sph_separation
+  final_iteration = 500
+  final_time = 10.0
+  out_screen_every = 1
+  out_scalar_every = 10
+  out_h5data_every = 10
+  output_h5data_prefix = "noh_evolution"
+

--- a/app/noh/test/noh_sqn100.par
+++ b/app/noh/test/noh_sqn100.par
@@ -7,7 +7,8 @@
   ### poly_gamma = 1.6666667  # polytropic index
   rho_initial = 1.0
   pressure_initial = 1.0e-6
-  sph_eta = 1.5
+  #sph_eta = 1.5
+  sph_separation = 0.001  # TODO: use sph_eta instead!!!
 
 # evolution parameters:
   initial_dt = 0.001      # TODO: better use Courant factor X sph_separation

--- a/app/sedov/generator/main.cc
+++ b/app/sedov/generator/main.cc
@@ -40,7 +40,7 @@ I.  Theoretical  Discussion,” Royal Society of London Proceedings Series A
 // help message
 //
 void print_usage() {
-  clog_one(warn) 
+  clog_one(warn)
       << "Initial data generator for the 2D Sedov blast wave" << std::endl
       << "Usage: ./sedov_generator <parameter-file.par>"      << std::endl;
 }
@@ -58,22 +58,28 @@ static char* fileprefix;    // output file (TODO: replace with a parmeter)
 
 static double u_blast;      // Injected total blast energy
 static double r_blast;      // Radius of injection region
+static std::string initial_data_file; // = initial_data_prefix + ".h5part"
 
 void set_derived_params() {
   using namespace param;
 
   // total number of particles
   SET_PARAM(nparticles, sqrt_nparticles*sqrt_nparticles);
-  
+
   ldistance = 0.001;  // Distance between the particles (TODO: sph_separation)
   rho_in = 1;                                       //  (TODO: rho_intial)
   pressure_in = 1.0e-7;                             //  (TODO: pressure_initial)
   u_in = pressure_in/(rho_in*(poly_gamma - 1.0));   //  (TODO: u_intial)
   smoothing_length = 5.*ldistance;                  //  (TODO: sph_smoothing_length)
-  fileprefix = "hdf5_sedov";                        //  (TODO: initial_data_prefix)
 
   u_blast = 1.0;         // Injected total blast energy (TODO: sedov_blast_energy)
   r_blast = ldistance;   // Radius of injection region  (TODO: sedov_blast_radius)
+
+  // file to be generated
+  std::ostringstream oss;
+  oss << initial_data_prefix << ".h5part";
+  initial_data_file = oss.str();
+
 }
 
 
@@ -233,17 +239,14 @@ int main(int argc, char * argv[]){
   }
 
   clog_one(info) << "Real number of particles: " << tparticles << std::endl;
-  clog_one(info) << "Total blast energy (E_blast = u_blast * total mass): " 
+  clog_one(info) << "Total blast energy (E_blast = u_blast * total mass): "
                  << u_blast * mass_blast << std::endl;
 
-  char filename[128];
-  sprintf(filename,"%s.h5part",fileprefix);
   // Remove the previous file
-  remove(filename);
-
+  remove(initial_data_file.c_str());
 
   Flecsi_Sim_IO::HDF5ParticleIO testDataSet;
-  testDataSet.createDataset(filename,MPI_COMM_WORLD);
+  testDataSet.createDataset(initial_data_file.c_str(),MPI_COMM_WORLD);
 
   // add the global attributes
   testDataSet.writeDatasetAttribute("nparticles","int64_t",tparticles);

--- a/app/sedov/generator/main.cc
+++ b/app/sedov/generator/main.cc
@@ -241,7 +241,7 @@ int main(int argc, char * argv[]){
   clog_one(info) << "Total blast energy (E_blast = u_blast * total mass): "
                  << u_blast * mass_blast << std::endl;
 
-  // Remove the previous file
+  // remove the previous file
   remove(initial_data_file.c_str());
 
   Flecsi_Sim_IO::HDF5ParticleIO testDataSet;

--- a/app/sedov/generator/main.cc
+++ b/app/sedov/generator/main.cc
@@ -54,7 +54,6 @@ static double rho_in;       // initial density
 static double pressure_in;  // initial pressure
 static double u_in;         // initial specific internal energy
 static double smoothing_length; // constant smoothing length
-static char* fileprefix;    // output file (TODO: replace with a parmeter)
 
 static double u_blast;      // Injected total blast energy
 static double r_blast;      // Radius of injection region

--- a/app/sedov/main_driver.cc
+++ b/app/sedov/main_driver.cc
@@ -57,7 +57,6 @@ mpi_init_task(int totaliterations){
   MPI_Comm_rank(MPI_COMM_WORLD,&rank);
   clog_set_output_rank(0);
   
-  int totaliters = totaliterations;
   int iteroutput = 10;
   //double totaltime = 0.0;
   double maxtime = 10.0;

--- a/app/sedov/main_driver.cc
+++ b/app/sedov/main_driver.cc
@@ -62,12 +62,6 @@ void set_derived_params() {
   physics::iteration = initial_iteration;
   physics::totaltime = initial_time;
   physics::dt = initial_dt; // TODO: use particle separation and Courant factor
-
-  // artificial SPH viscosity
-  physics::alpha = 2;       // TODO: sph_viscosity_alpha
-  physics::beta = 2;        // TODO: sph_viscosity_beta
-  physics::epsilon = 0.01;  // TODO: sph_viscosity_eps
-
 }
 
 namespace flecsi{

--- a/app/sedov/main_driver.cc
+++ b/app/sedov/main_driver.cc
@@ -37,6 +37,7 @@
 #include "flecsi/data/data_client.h"
 #include "flecsi/data/data.h"
 
+#include "params.h"
 #include <bodies_system.h>
 
 #include "default_physics.h"
@@ -67,7 +68,7 @@ mpi_init_task(int totaliterations){
   physics::beta = 2; 
   physics::do_boundaries = false;
   physics::stop_boundaries = false;
-  physics::gamma = 1.4; // Set to fit value in default_physics.h
+  ///physics::gamma = 1.4; // converted to a parameter (poly_gamma)
   physics::epsilon = 0.01;
 
   body_system<double,gdimension> bs;

--- a/app/sedov/main_driver.cc
+++ b/app/sedov/main_driver.cc
@@ -91,7 +91,7 @@ mpi_init_task(const char * parameter_file){
   // boundaries
   auto range_boundaries = bs.getRange();
   point_t distance = range_boundaries[1]-range_boundaries[0];
-  for(int i = 0; i < gdimension; ++i){
+  for(unsigned short i = 0; i < gdimension; ++i){
     distance[i] = fabs(distance[i]);
   }
   double h = bs.getSmoothinglength();

--- a/app/sedov/test/sedov_sqn100.par
+++ b/app/sedov/test/sedov_sqn100.par
@@ -7,7 +7,8 @@
   poly_gamma = 1.4        # polytropic index
   rho_initial = 1.0
   pressure_initial = 1.0e-7
-  sph_eta = 1.5
+  sph_separation = 0.001  # TODO: use sph_eta instead
+  #sph_eta = 1.5
   sedov_blast_energy = 1.0
   sedov_blast_radius = 1.0 # in units of particle separation
 

--- a/app/sedov/test/sedov_sqn100.par
+++ b/app/sedov/test/sedov_sqn100.par
@@ -1,0 +1,21 @@
+#
+# Sedov blast wave test
+#
+## initial data
+  initial_data_prefix = "sedov_sqn100"
+  sqrt_nparticles = 100   # sqrt of the total number of particles
+  poly_gamma = 1.4        # polytropic index
+  rho_initial = 1.0
+  pressure_initial = 1.0e-7
+  sph_eta = 1.5
+  sedov_blast_energy = 1.0
+  sedov_blast_radius = 1.0 # in units of particle separation
+
+# evolution parameters:
+  initial_dt = 0.0025 # TODO: better use Courant factor X sph_separation
+  final_iteration = 50
+  out_screen_every = 1
+  out_scalar_every = 10
+  out_h5data_every = 10
+  output_h5data_prefix = "sedov_evolution"
+

--- a/app/sodtube/generator/main.cc
+++ b/app/sodtube/generator/main.cc
@@ -24,10 +24,7 @@ void print_usage() {
 //
 // derived parameters
 //
-static int64_t nparticlesproc;    // number of particles per proc
-static double ldistance;          // particles spacing  (TODO: sph_separation)
-static double smoothing_length;   // constant smoothing length (TODO: sph_smoothing_length)
-
+static int64_t nparticlesproc;        // number of particles per proc
 static double rho_1, rho_2;           // densities
 static double vx_1, vx_2;             // velocities
 static double pressure_1, pressure_2; // pressures
@@ -44,8 +41,8 @@ void set_derived_params(int rank, int size) {
   }
 
   // particle spacing and smoothing length
-  ldistance = 1.0/(double)nparticles;
-  smoothing_length = ldistance*10; // TODO: introduce \eta parameter
+  SET_PARAM(sph_separation, 1.0/(double)nparticles);
+  SET_PARAM(sph_smoothing_length, (sph_separation*10)); // TODO: use sph_eta instead
 
   // test selector
   switch (sodtest_num) {
@@ -155,9 +152,9 @@ int main(int argc, char * argv[]){
 
   // Generate data
   // Find middle to switch m, u and rho
-  double middle = nparticles*ldistance/2.;
+  double middle = nparticles*sph_separation/2.;
   // Find my first particle position
-  double lposition = ldistance*nparticlesproc*rank;
+  double lposition = sph_separation*nparticlesproc*rank;
   // Id of my first particle
   int64_t posid = nparticlesproc*rank;
 
@@ -165,7 +162,7 @@ int main(int argc, char * argv[]){
   double cs = sqrt(poly_gamma*max(pressure_1/rho_1,pressure_2/rho_2));
 
   // The value for constant timestep
-  double timestep = 0.5*ldistance/cs;
+  double timestep = 0.5*sph_separation/cs;
 
 
   for(int64_t part=0; part<nparticlesproc; ++part){
@@ -186,12 +183,12 @@ int main(int argc, char * argv[]){
     u[part] = P[part]/(poly_gamma-1.)/rho[part];
 
     // particle masses and smoothing length
-    m[part] = rho[part]*smoothing_length/10.;
-    h[part] = smoothing_length;
+    m[part] = rho[part]*sph_smoothing_length/10.;
+    h[part] = sph_smoothing_length;
 
     // P,Y,Z,VY,VZ,AX,AY,AZ stay 0
     // Move to the next particle
-    lposition += ldistance;
+    lposition += sph_separation;
 
   } // for part=0..nparticles
 

--- a/app/sodtube/generator/main.cc
+++ b/app/sodtube/generator/main.cc
@@ -9,6 +9,14 @@
 
 #include "hdf5ParticleIO.h"
 #include "kernels.h"
+
+// parameters: #define here, or read from a parameter file
+namespace param {
+//# define nparticles 1000
+//# define sodtest_num  1
+//# define poly_gamma  1.4
+//# define initial_data_h5part "sodtube_initial_t1n100.h5part"
+}
 #include "params.h"
 
 static int64_t nparticlesproc;    // number of particles per proc
@@ -107,7 +115,6 @@ int main(int argc, char * argv[]){
   }
 
   // set simulation parameters
-  set_default_params(rank,size);
   string parfile(argv[1]);
   read_params(parfile);
   set_derived_params(rank,size);

--- a/app/sodtube/generator/main.cc
+++ b/app/sodtube/generator/main.cc
@@ -31,7 +31,7 @@ static double smoothing_length;   // constant smoothing length
 static double rho_1, rho_2;           // densities
 static double vx_1, vx_2;             // velocities
 static double pressure_1, pressure_2; // pressures
-static std::string initial_data_file; // = initial_data_prefix + ".h5part"       
+static std::string initial_data_file; // = initial_data_prefix + ".h5part"
 
 void set_derived_params(int rank, int size) {
   using namespace std;
@@ -114,15 +114,14 @@ int main(int argc, char * argv[]){
   }
 
   // set simulation parameters
-  string parfile(argv[1]);
-  read_params(parfile);
+  param::mpi_read_params();
   set_derived_params(rank,size);
 
   // screen output
   clog_one(info) << "Sod test #" << sodtest_num << " in 1D:" << endl
          << " - number of particles: " << nparticles << endl
          << " - particles per core:  " << nparticlesproc << endl
-         << " - generated initial data file: " 
+         << " - generated initial data file: "
          << initial_data_file << endl;
 
   // allocate arrays

--- a/app/sodtube/generator/main.cc
+++ b/app/sodtube/generator/main.cc
@@ -25,8 +25,8 @@ void print_usage() {
 // derived parameters
 //
 static int64_t nparticlesproc;    // number of particles per proc
-static double ldistance;          // particles spacing
-static double smoothing_length;   // constant smoothing length
+static double ldistance;          // particles spacing  (TODO: sph_separation)
+static double smoothing_length;   // constant smoothing length (TODO: sph_smoothing_length)
 
 static double rho_1, rho_2;           // densities
 static double vx_1, vx_2;             // velocities
@@ -114,7 +114,7 @@ int main(int argc, char * argv[]){
   }
 
   // set simulation parameters
-  param::mpi_read_params();
+  param::mpi_read_params(argv[1]);
   set_derived_params(rank,size);
 
   // screen output

--- a/app/sodtube/main_driver.cc
+++ b/app/sodtube/main_driver.cc
@@ -37,6 +37,7 @@
 #include "flecsi/data/data_client.h"
 #include "flecsi/data/data.h"
 
+#include "params.h"
 #include "bodies_system.h"
 #include "default_physics.h"
 #include "analysis.h"
@@ -47,8 +48,7 @@ namespace flecsi{
 namespace execution{
 
 void
-mpi_init_task(int numberiterations){
-  // TODO find a way to use the file name from the specialiszation_driver
+mpi_init_task(){
   
   int rank;
   int size;
@@ -153,28 +153,36 @@ mpi_init_task(int numberiterations){
     ++physics::iteration;
     physics::totaltime += physics::dt;
     
-  }while(physics::iteration<numberiterations);
+  }while(physics::iteration <= param::final_iteration);
 }
 
 flecsi_register_mpi_task(mpi_init_task);
 
-void usage()
-{
-  clog_one(warn)<<"./sodtube [number of iterations]"<<std::endl;
+//
+// help message
+//
+void usage() {
+  clog_one(warn) << "Usage: ./sodtube <parameter-file.par>" 
+                 << std::endl << std::flush;
 }
 
 void 
 specialization_tlt_init(int argc, char * argv[]){
   
-  // Default start at iteration 0
-  usage();
-
-  int numberiterations = 100;
-  if(argc == 2){
-    numberiterations = atoi(argv[1]);
+  // check options list: exactly one option is allowed
+  if (argc != 2) {
+    clog_one(error) << "ERROR: parameter file not specified!" << std::endl;
+    usage();
+    return;
   }
+
+  // set simulation parameters
+  std::string parfile(argv[1]);
+  param::read_params(parfile);
+  //set_derived_params(rank,size);
+
   clog_one(trace) << "In user specialization_driver" << std::endl;
-  flecsi_execute_mpi_task(mpi_init_task,numberiterations); 
+  flecsi_execute_mpi_task(mpi_init_task); 
 } // specialization driver
 
 void 

--- a/app/sodtube/main_driver.cc
+++ b/app/sodtube/main_driver.cc
@@ -48,7 +48,7 @@ namespace flecsi{
 namespace execution{
 
 void
-mpi_init_task(){
+mpi_init_task(const char * parameter_file){
   using namespace param;
   
   int rank;
@@ -56,6 +56,11 @@ mpi_init_task(){
   MPI_Comm_size(MPI_COMM_WORLD,&size);
   MPI_Comm_rank(MPI_COMM_WORLD,&rank);
   clog_set_output_rank(0);
+
+  // set simulation parameters
+  param::mpi_read_params(parameter_file);
+  //set_derived_params(rank,size);
+
   
   // Init if default values are not ok
   physics::dt = 0.0025;
@@ -173,13 +178,8 @@ specialization_tlt_init(int argc, char * argv[]){
     return;
   }
 
-  // set simulation parameters
-  std::string parfile(argv[1]);
-  param::read_params(parfile);
-  //set_derived_params(rank,size);
-
   clog_one(trace) << "In user specialization_driver" << std::endl;
-  flecsi_execute_mpi_task(mpi_init_task); 
+  flecsi_execute_mpi_task(mpi_init_task, argv[1]); 
 } // specialization driver
 
 void 

--- a/app/sodtube/main_driver.cc
+++ b/app/sodtube/main_driver.cc
@@ -47,7 +47,7 @@
 static std::string initial_data_file;  // = initial_data_prefix  + ".h5part"
 static std::string output_h5data_file; // = output_h5data_prefix + ".h5part"
 
-void set_derived_params(int rank, int size) {
+void set_derived_params() {
   using namespace param;
 
   // filenames (this will change for multiple files output)
@@ -84,7 +84,7 @@ mpi_init_task(const char * parameter_file){
 
   // set simulation parameters
   param::mpi_read_params(parameter_file);
-  set_derived_params(rank,size);
+  set_derived_params();
 
   // remove output file
   remove(output_h5data_file.c_str());
@@ -140,7 +140,7 @@ mpi_init_task(const char * parameter_file){
     bs.apply_in_smoothinglength(physics::compute_dudt);
     clog_one(trace) << ".done" << std::endl;
 
-    if(physics::iteration==1){
+    if(physics::iteration == initial_iteration + 1){
       clog_one(trace) << "leapfrog" << std::flush;
       bs.apply_all(physics::leapfrog_integration_first_step);
       clog_one(trace) << ".done" << std::endl;

--- a/app/sodtube/main_driver.cc
+++ b/app/sodtube/main_driver.cc
@@ -62,11 +62,6 @@ void set_derived_params() {
   physics::totaltime = initial_time;
   physics::dt = initial_dt; // TODO: use particle separation and Courant factor
 
-  // artificial SPH viscosity
-  physics::alpha = 1;       // TODO: sph_viscosity_alpha
-  physics::beta = 2;        // TODO: sph_viscosity_beta
-  physics::epsilon = 0.01;  // TODO: sph_viscosity_eps
-
 }
 
 namespace flecsi{

--- a/app/sodtube/main_driver.cc
+++ b/app/sodtube/main_driver.cc
@@ -56,9 +56,8 @@ mpi_init_task(int numberiterations){
   MPI_Comm_rank(MPI_COMM_WORLD,&rank);
   clog_set_output_rank(0);
   
-  int totaliters = numberiterations;
   int iteroutput = 1;
-  double maxtime = 10.0;
+  double maxtime = 10.0; // TODO: this is never used.
 
   // Init if default values are not ok
   physics::dt = 0.0025;
@@ -154,7 +153,7 @@ mpi_init_task(int numberiterations){
     ++physics::iteration;
     physics::totaltime += physics::dt;
     
-  }while(physics::iteration<totaliters);
+  }while(physics::iteration<numberiterations);
 }
 
 flecsi_register_mpi_task(mpi_init_task);

--- a/app/sodtube/main_driver.cc
+++ b/app/sodtube/main_driver.cc
@@ -49,6 +49,7 @@ namespace execution{
 
 void
 mpi_init_task(){
+  using namespace param;
   
   int rank;
   int size;
@@ -65,7 +66,6 @@ mpi_init_task(){
   physics::beta = 2; 
   physics::do_boundaries = true;
   physics::stop_boundaries = true;
-  physics::gamma = 1.4;
   physics::epsilon = 0.01;
 
   const char * inputFile = "hdf5_sodtube.h5part";
@@ -153,7 +153,7 @@ mpi_init_task(){
     ++physics::iteration;
     physics::totaltime += physics::dt;
     
-  }while(physics::iteration <= param::final_iteration);
+  }while(physics::iteration <= final_iteration);
 }
 
 flecsi_register_mpi_task(mpi_init_task);

--- a/app/sodtube/main_driver.cc
+++ b/app/sodtube/main_driver.cc
@@ -57,9 +57,6 @@ mpi_init_task(){
   MPI_Comm_rank(MPI_COMM_WORLD,&rank);
   clog_set_output_rank(0);
   
-  int iteroutput = 1;
-  double maxtime = 10.0; // TODO: this is never used.
-
   // Init if default values are not ok
   physics::dt = 0.0025;
   physics::alpha = 1; 
@@ -146,8 +143,8 @@ mpi_init_task(){
 #endif
 
 #ifdef OUTPUT
-    if(physics::iteration % iteroutput == 0){ 
-      bs.write_bodies("output_sodtube",physics::iteration/iteroutput);
+    if(out_h5data_every > 0 && physics::iteration % out_h5data_every == 0){ 
+      bs.write_bodies("output_sodtube",physics::iteration/out_h5data_every);
     }
 #endif
     ++physics::iteration;

--- a/app/sodtube/test/sodtube_t1_n100.par
+++ b/app/sodtube/test/sodtube_t1_n100.par
@@ -1,8 +1,17 @@
-# Sodtube test #1 for 100 particles
+#
+# Sodtube test #1 for 1000 particles
+#
+# initial data
   nparticles= 1000    # global number of particles                                                                    
   poly_gamma = 1.4    # polytropic index
   sodtest_num  = 1    # which test to generate                                                                    
-  initial_data_prefix = "hdf5_sodtube"
- # initial_data_prefix = "sodtube_initial_t1n100"
+  initial_data_prefix = "sodtube_t1_n100"
+
+# evolution
+  initial_dt = 0.0025
   final_iteration = 50
+  out_screen_every = 1
+  out_scalar_every = 10
+  out_h5data_every = 10
+  output_h5data_prefix = "sodtube_evolution"
 

--- a/app/sodtube/test/sodtube_t1_n100.par
+++ b/app/sodtube/test/sodtube_t1_n100.par
@@ -2,6 +2,6 @@
   nparticles= 1000    # global number of particles                                                                    
   poly_gamma = 1.4    # polytropic index
   sodtest_num  = 1    # which test to generate                                                                    
-  initial_data_h5part= "hdf5_sodtube.h5part"
- # initial_data_h5part = "sodtube_initial_t1n100.h5part"
+  initial_data_prefix = "hdf5_sodtube"
+ # initial_data_prefix = "sodtube_initial_t1n100"
 

--- a/app/sodtube/test/sodtube_t1_n100.par
+++ b/app/sodtube/test/sodtube_t1_n100.par
@@ -4,4 +4,5 @@
   sodtest_num  = 1    # which test to generate                                                                    
   initial_data_prefix = "hdf5_sodtube"
  # initial_data_prefix = "sodtube_initial_t1n100"
+  final_iteration = 50
 

--- a/app/sodtube/test/sodtube_t1_n100.par
+++ b/app/sodtube/test/sodtube_t1_n100.par
@@ -1,0 +1,7 @@
+# Sodtube test #1 for 100 particles
+  nparticles= 1000    # global number of particles                                                                    
+  poly_gamma = 1.4    # polytropic index
+  sodtest_num  = 1    # which test to generate                                                                    
+  initial_data_h5part= "hdf5_sodtube.h5part"
+ # initial_data_h5part = "sodtube_initial_t1n100.h5part"
+

--- a/include/params.h
+++ b/include/params.h
@@ -101,6 +101,10 @@
 #define READ_STRING_PARAM(PNAME) \
   if (param_name == QUOTE(PNAME)) { \
     strcpy(_##PNAME, str_value.c_str()); unknown_param = false;}
+
+#define SET_PARAM(PNAME,EXPR) _##PNAME = (EXPR); 
+// TODO: the macro above won't work for strings!
+
 //////////////////////////////////////////////////////////////////////
 
 namespace param {
@@ -236,6 +240,22 @@ namespace param {
 #ifndef sodtest_num
   DECLARE_PARAM(unsigned short,sodtest_num,1)
 #endif
+
+// characteristic density for an initial conditions
+# ifndef rho_initial
+  DECLARE_PARAM(double,rho_initial,1.0)
+# endif
+
+// characteristic pressure
+# ifndef pressure_initial
+  DECLARE_PARAM(double,pressure_initial,1.0)
+# endif
+
+// characteristic specific internal energy
+# ifndef uint_initial
+  DECLARE_PARAM(double,uint_initial,1.0)
+# endif
+
 // ---
 
 /*!
@@ -376,8 +396,16 @@ void set_param(const std::string& param_name,
   READ_NUMERIC_PARAM(sodtest_num)
 # endif
 
-# ifndef poly_gamma
-  READ_NUMERIC_PARAM(poly_gamma)
+# ifndef rho_initial
+  READ_NUMERIC_PARAM(rho_initial)
+# endif
+
+# ifndef pressure_initial
+  READ_NUMERIC_PARAM(pressure_initial)
+# endif
+
+# ifndef uint_initial
+  READ_NUMERIC_PARAM(uint_initial)
 # endif
 
   // unknown parameter -------------------------------
@@ -487,7 +515,7 @@ void mpi_read_params(const char * parameter_file) {
   MPI_Bcast(parfile, len+1, MPI_CHAR, 0, MPI_COMM_WORLD);
 
   clog(trace) << "Parameter file name on rank " << rank
-              << ": " << parfile << std::endl;
+              << ": " << parfile << std::endl << std::flush;
 
   // queue ranks to read the parfile sequentially;
   // wait for a message from previous rank, unless this is rank 0

--- a/include/params.h
+++ b/include/params.h
@@ -477,7 +477,7 @@ void read_params(const char * parfile) {
     // skip comments (lines starting with '#' at any position)
     // and blank lines
     bool is_blank = true, is_comment = false;
-    for (int i=0;i<line.length();i++) {
+    for (size_t i=0;i<line.length();i++) {
       char c = line[i];
       is_comment = (c == '#');
       is_blank = (c == ' ' || c == '\t');

--- a/include/params.h
+++ b/include/params.h
@@ -120,6 +120,11 @@
 
 namespace param {
 
+/// final iteration (= total iterations + 1, if counting from 0)
+#ifndef final_iteration
+  DECLARE_PARAM(int64_t,final_iteration,10)
+#endif
+
 /// global number of particles
 #ifndef nparticles
   DECLARE_PARAM(int64_t,nparticles,1000)
@@ -196,6 +201,10 @@ void set_param(const std::string& param_name,
 # endif
 
   // integer parameters ------------------------------
+# ifndef final_iteration
+    READ_NUMERIC_PARAM(final_iteration)
+# endif
+
 # ifndef nparticles
     READ_NUMERIC_PARAM(nparticles)
 # endif

--- a/include/params.h
+++ b/include/params.h
@@ -73,6 +73,7 @@
 #include <stdlib.h>
 #include <assert.h>
 #include "cinchlog.h"
+#include "mpi.h"
 
 #ifndef PARAMS_H
 #define PARAMS_H

--- a/include/params.h
+++ b/include/params.h
@@ -105,16 +105,86 @@
 
 namespace param {
 
-/// final iteration (= total iterations + 1, if counting from 0)
+//
+// Parameters controlling timestepping and iterations
+// 
+//- initial iteration
+#ifndef initial_iteration
+  DECLARE_PARAM(int64_t,initial_iteration,0)
+#endif
+
+//- final iteration (= total iterations + 1, if counting from 0)
 #ifndef final_iteration
   DECLARE_PARAM(int64_t,final_iteration,10)
 #endif
 
-/// global number of particles
+#ifndef initial_time
+  DECLARE_PARAM(int64_t,initial_time,0)
+#endif
+
+#ifndef final_time
+  DECLARE_PARAM(int64_t,final_time,1.0)
+#endif
+
+//- inital timestep
+#ifndef initial_dt
+  DECLARE_PARAM(double,initial_dt,0.001)
+#endif
+
+//
+// Parameters related to particle number and density
+// 
+//- global number of particles
 #ifndef nparticles
   DECLARE_PARAM(int64_t,nparticles,1000)
 #endif
 
+//- SPH eta parameter, eta = h (rho/m)^1/D (Rosswog'09, eq.51)
+#ifndef sph_eta
+  DECLARE_PARAM(double,sph_eta,1.5)
+#endif
+
+//- if smoothing length is constant: value of the smoothing length
+#ifndef sph_smoothing_length
+  DECLARE_PARAM(double,sph_smoothing_length,-1.0) // POISONED DEFAULT
+#endif
+
+//- minimum interparticle distance (for some initial data problems)
+#ifndef sph_separation
+  DECLARE_PARAM(double,sph_separation,-1.0) // POISONED DEFAULT
+#endif
+
+//
+// I/O parameters
+// 
+//- file prefix for input and intiial data file[s]
+#ifndef initial_data_prefix
+  DECLARE_STRING_PARAM(initial_data_prefix,"initial_data")
+#endif
+
+//- file prefix for HDF5 output data file[s]
+#ifndef output_h5data_prefix
+  DECLARE_STRING_PARAM(output_h5data_prefix,"output_data")
+#endif
+
+//- screen output frequency
+#ifndef out_screen_every
+  DECLARE_PARAM(int32_t,out_screen_every,1)
+#endif
+
+//- scalar reductions output frequency
+#ifndef out_scalar_every
+  DECLARE_PARAM(int32_t,out_scalar_every,10)
+#endif
+
+//- HDF5 output frequency
+#ifndef out_h5data_every
+  DECLARE_PARAM(int32_t,out_h5data_every,10)
+#endif
+
+//
+// Specific apps
+// 
 /// number of Sodtest to run (1..5)
 #ifndef sodtest_num
   DECLARE_PARAM(unsigned short,sodtest_num,1)
@@ -123,16 +193,6 @@ namespace param {
 /// polytropic index
 #ifndef poly_gamma
   DECLARE_PARAM(double,poly_gamma,1.4)
-#endif
-
-/// inital timestep
-#ifndef initial_dt
-  DECLARE_PARAM(double,initial_dt,0.001)
-#endif
-
-/// file prefix for input and intiial data file[s]
-#ifndef initial_data_prefix
-  DECLARE_STRING_PARAM(initial_data_prefix,"initial_data")
 #endif
 
 /// a test boolean parameter
@@ -177,39 +237,82 @@ void set_param(const std::string& param_name,
     str_value = str_value.substr(1,str_value.length()-2);
   istringstream iss(str_value);
 
-  // boolean parameters ------------------------------
+  // for boolean parameters 
   bool lparam_value = (str_value == "yes"
                     or str_value == "'yes'"
                     or str_value == "\"yes\"");
-# ifndef run_job
-    READ_BOOLEAN_PARAM(run_job)
+  // timestepping and iterations --------------------------------------------
+# ifndef initial_iteration
+  READ_NUMERIC_PARAM(initial_iteration)
 # endif
 
-  // integer parameters ------------------------------
 # ifndef final_iteration
-    READ_NUMERIC_PARAM(final_iteration)
+  READ_NUMERIC_PARAM(final_iteration)
 # endif
 
-# ifndef nparticles
-    READ_NUMERIC_PARAM(nparticles)
+# ifndef initial_time
+  READ_NUMERIC_PARAM(initial_time)
 # endif
 
-# ifndef sodtest_num
-    READ_NUMERIC_PARAM(sodtest_num)
-# endif
-
-  // real parameters ---------------------------------
-# ifndef poly_gamma
-    READ_NUMERIC_PARAM(poly_gamma)
+# ifndef final_time
+  READ_NUMERIC_PARAM(final_time)
 # endif
 
 # ifndef initial_dt
-    READ_NUMERIC_PARAM(initial_dt)
+  READ_NUMERIC_PARAM(initial_dt)
 # endif
 
-  // string parameters -------------------------------
+
+  // particle number and density --------------------------------------------
+# ifndef nparticles
+  READ_NUMERIC_PARAM(nparticles)
+# endif
+
+# ifndef sph_eta
+  READ_NUMERIC_PARAM(sph_eta)
+# endif
+
+# ifndef sph_smoothing_length
+  READ_NUMERIC_PARAM(sph_smoothing_length)
+# endif
+
+# ifndef sph_separation
+  READ_NUMERIC_PARAM(sph_separation)
+# endif
+
+
+  // i/o parameters  --------------------------------------------------------
 # ifndef initial_data_prefix
-    READ_STRING_PARAM(initial_data_prefix)
+  READ_STRING_PARAM(initial_data_prefix)
+# endif
+
+# ifndef output_h5data_prefix
+  READ_STRING_PARAM(output_h5data_prefix)
+# endif
+
+# ifndef out_screen_every
+  READ_NUMERIC_PARAM(out_screen_every)
+# endif
+
+# ifndef out_scalar_every
+  READ_NUMERIC_PARAM(out_scalar_every)
+# endif
+
+# ifndef out_h5data_every
+  READ_NUMERIC_PARAM(out_h5data_every)
+# endif
+
+  // specific apps  ---------------------------------------------------------
+# ifndef sodtest_num
+  READ_NUMERIC_PARAM(sodtest_num)
+# endif
+
+# ifndef poly_gamma
+  READ_NUMERIC_PARAM(poly_gamma)
+# endif
+
+# ifndef run_job
+  READ_BOOLEAN_PARAM(run_job)
 # endif
 
   // unknown parameter -------------------------------

--- a/include/params.h
+++ b/include/params.h
@@ -31,6 +31,9 @@
 #include <stdlib.h>
 #include <assert.h>
 
+#ifndef PARAMS_H
+#define PARAMS_H
+
 #define MAXLEN_FNAME 255
 
 namespace param {
@@ -199,3 +202,4 @@ void read_params(std::string parfile) {
 
 } // namespace params
 
+#endif // PARAMS_H

--- a/include/params.h
+++ b/include/params.h
@@ -54,14 +54,11 @@
  * parameter has been defined via macro, it needs to be commented out in a 
  * parametre file.  An example of #defining parameters:
 
- namespace param {
- #   define nparticles 1000
- #   define sodtest_num  1
- #   define poly_gamma  1.4
- #   define initial_data_h5part "sodtube_initial_t1n100.h5part"
- } // namespace param
- #include "params.h" // Note how "params.h" is included *after* the 
-                     // definitions
+ #define nparticles 1000
+ #define sodtest_num  1
+ #define poly_gamma  1.4
+ #define initial_data_h5part "sodtube_initial_t1n100.h5part"
+ #include "params.h" // "params.h" is included *after* definitions
 
  * To introduce a new parameter:
  *  - add its declaration below using DECLARE_PARAM or DECLARE_STRING_PARAM 

--- a/include/params.h
+++ b/include/params.h
@@ -48,26 +48,19 @@
  * ignored.
  *
  * All parameters in a parfile have exactly the same name as in the code, to
- * avoid confusion. All parameters are declared as const references in the
- * param:: namespace. It is also possible to #define a parameter instead to
- * ioptimze the performance. In this case, when a parameter has been defined via 
- * a macro, it needs to be commented out in a parametre file. 
+ * avoid confusion. Parameters are read-only (const references) in the param::
+ * namespace. It is also possible to #define a parameter instead for optimized
+ * performance -- in this case, however, this parameter needs to be commented out
+ * in the parameter file. 
  *
- * Example of #define-ing parameters:
- * 
- *  #define nparticles 1000
- *  #define sodtest_num  1
- *  #define poly_gamma  1.4
- *  #define initial_data_prefix "sodtube_n10k"
- * 
  * To introduce a new parameter:
- *  - add its declaration below using DECLARE_PARAM or DECLARE_STRING_PARAM 
+ *  - add its declaration below using DECLARE_PARAM or DECLARE_STRING_PARAM
  *    macro (see below);
  *  - add REAL_NUMERIC_PARAM, READ_BOOLEAN_PARAM or READ_STRING_PARAM
  *    to the set_param() function -- see examples below.
  *
  * TODO: introduce a set of macros to do both declaration and reading:
- *       REGISTER_BOOLEAN_PARAM, REGISTER_INTEGER_PARAM, 
+ *       REGISTER_BOOLEAN_PARAM, REGISTER_INTEGER_PARAM,
  *       REGISTER_STRING_PARAM, REGISTER_REAL_PARAM
  *       instead of DECLARE/READ pair
  */
@@ -108,15 +101,7 @@
 #define READ_STRING_PARAM(PNAME) \
   if (param_name == QUOTE(PNAME)) { \
     strcpy(_##PNAME, str_value.c_str()); unknown_param = false;}
-
-//\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\
-///
-/// Parameter #define-s: uncomment to fix parameters at compile time:
-///
-//#define nparticles 1000
-//#define sodtest_num  1
-//#define poly_gamma  1.4
-//#define initial_data_prefix "initial_data"
+//////////////////////////////////////////////////////////////////////
 
 namespace param {
 

--- a/include/params.h
+++ b/include/params.h
@@ -102,7 +102,7 @@
   if (param_name == QUOTE(PNAME)) { \
     strcpy(_##PNAME, str_value.c_str()); unknown_param = false;}
 
-#define SET_PARAM(PNAME,EXPR) _##PNAME = (EXPR); 
+#define SET_PARAM(PNAME,EXPR) _##PNAME = (EXPR);
 // TODO: the macro above won't work for strings!
 
 //////////////////////////////////////////////////////////////////////
@@ -222,14 +222,14 @@ namespace param {
   DECLARE_PARAM(double,sph_viscosity_alpha,1.0)
 #endif
 
-//- artificial viscosity: parameter beta (Rosswog'09, eq.59)
+//- artificial viscosity: parameter beta
 #ifndef sph_viscosity_beta
   DECLARE_PARAM(double,sph_viscosity_beta,2.0)
 #endif
 
-//- artificial viscosity: parameter eta (Rosswog'09, eq.59)
-#ifndef sph_viscosity_beta
-  DECLARE_PARAM(double,sph_viscosity_eta,0.01)
+//- artificial viscosity: parameter eta
+#ifndef sph_viscosity_epsilon
+  DECLARE_PARAM(double,sph_viscosity_epsilon,0.01)
 #endif
 
 
@@ -398,8 +398,8 @@ void set_param(const std::string& param_name,
   READ_NUMERIC_PARAM(sph_viscosity_beta)
 # endif
 
-# ifndef sph_viscosity_beta
-  READ_NUMERIC_PARAM(sph_viscosity_eta)
+# ifndef sph_viscosity_epsilon
+  READ_NUMERIC_PARAM(sph_viscosity_epsilon)
 # endif
 
   // specific apps  ---------------------------------------------------------

--- a/include/params.h
+++ b/include/params.h
@@ -51,7 +51,7 @@
  * avoid confusion. Parameters are read-only (const references) in the param::
  * namespace. It is also possible to #define a parameter instead for optimized
  * performance -- in this case, however, this parameter needs to be commented out
- * in the parameter file. 
+ * in the parameter file.
  *
  * To introduce a new parameter:
  *  - add its declaration below using DECLARE_PARAM or DECLARE_STRING_PARAM
@@ -107,7 +107,7 @@ namespace param {
 
 //
 // Parameters controlling timestepping and iterations
-// 
+//
 //- initial iteration
 #ifndef initial_iteration
   DECLARE_PARAM(int64_t,initial_iteration,0)
@@ -133,7 +133,7 @@ namespace param {
 
 //
 // Parameters related to particle number and density
-// 
+//
 //- global number of particles
 #ifndef nparticles
   DECLARE_PARAM(int64_t,nparticles,1000)
@@ -155,8 +155,26 @@ namespace param {
 #endif
 
 //
+// Boundary conditions
+//
+//- TODO: add description
+#ifndef do_boundaries
+  DECLARE_PARAM(bool,do_boundaries,false)
+#endif
+
+//- TODO: add description
+#ifndef stop_boundaries
+  DECLARE_PARAM(bool,stop_boundaries,false)
+#endif
+
+//- TODO: add description
+#ifndef reflect_boundaries
+  DECLARE_PARAM(bool,reflect_boundaries,false)
+#endif
+
+//
 // I/O parameters
-// 
+//
 //- file prefix for input and intiial data file[s]
 #ifndef initial_data_prefix
   DECLARE_STRING_PARAM(initial_data_prefix,"initial_data")
@@ -184,7 +202,7 @@ namespace param {
 
 //
 // Viscosity and equation of state
-// 
+//
 //- polytropic index
 #ifndef poly_gamma
   DECLARE_PARAM(double,poly_gamma,1.4)
@@ -208,15 +226,10 @@ namespace param {
 
 //
 // Specific apps
-// 
+//
 /// number of Sodtest to run (1..5)
 #ifndef sodtest_num
   DECLARE_PARAM(unsigned short,sodtest_num,1)
-#endif
-
-/// a test boolean parameter
-#ifndef run_job
-  DECLARE_PARAM(bool,run_job,false)
 #endif
 // ---
 
@@ -240,7 +253,6 @@ std::string trim(const std::string& str) {
 void set_param(const std::string& param_name,
                const std::string& param_value) {
   using namespace std;
-  bool run_job;
   bool unknown_param = true;
 
   // strip trailing comments
@@ -256,7 +268,7 @@ void set_param(const std::string& param_name,
     str_value = str_value.substr(1,str_value.length()-2);
   istringstream iss(str_value);
 
-  // for boolean parameters 
+  // for boolean parameters
   bool lparam_value = (str_value == "yes"
                     or str_value == "'yes'"
                     or str_value == "\"yes\"");
@@ -299,6 +311,18 @@ void set_param(const std::string& param_name,
   READ_NUMERIC_PARAM(sph_separation)
 # endif
 
+  // boundary conditions  ---------------------------------------------------
+# ifndef do_boundaries
+  READ_BOOLEAN_PARAM(do_boundaries)
+# endif
+
+# ifndef stop_boundaries
+  READ_BOOLEAN_PARAM(stop_boundaries)
+# endif
+
+# ifndef reflect_boundaries
+  READ_BOOLEAN_PARAM(reflect_boundaries)
+# endif
 
   // i/o parameters  --------------------------------------------------------
 # ifndef initial_data_prefix
@@ -345,10 +369,6 @@ void set_param(const std::string& param_name,
 
 # ifndef poly_gamma
   READ_NUMERIC_PARAM(poly_gamma)
-# endif
-
-# ifndef run_job
-  READ_BOOLEAN_PARAM(run_job)
 # endif
 
   // unknown parameter -------------------------------

--- a/include/params.h
+++ b/include/params.h
@@ -183,16 +183,35 @@ namespace param {
 #endif
 
 //
+// Viscosity and equation of state
+// 
+//- polytropic index
+#ifndef poly_gamma
+  DECLARE_PARAM(double,poly_gamma,1.4)
+#endif
+
+//- artificial viscosity: parameter alpha (Rosswog'09, eq.59)
+#ifndef sph_viscosity_alpha
+  DECLARE_PARAM(double,sph_viscosity_alpha,1.0)
+#endif
+
+//- artificial viscosity: parameter beta (Rosswog'09, eq.59)
+#ifndef sph_viscosity_beta
+  DECLARE_PARAM(double,sph_viscosity_beta,2.0)
+#endif
+
+//- artificial viscosity: parameter eta (Rosswog'09, eq.59)
+#ifndef sph_viscosity_beta
+  DECLARE_PARAM(double,sph_viscosity_eta,0.01)
+#endif
+
+
+//
 // Specific apps
 // 
 /// number of Sodtest to run (1..5)
 #ifndef sodtest_num
   DECLARE_PARAM(unsigned short,sodtest_num,1)
-#endif
-
-/// polytropic index
-#ifndef poly_gamma
-  DECLARE_PARAM(double,poly_gamma,1.4)
 #endif
 
 /// a test boolean parameter
@@ -300,6 +319,23 @@ void set_param(const std::string& param_name,
 
 # ifndef out_h5data_every
   READ_NUMERIC_PARAM(out_h5data_every)
+# endif
+
+  // viscosity and equation of state ----------------------------------------
+# ifndef poly_gamma
+  READ_NUMERIC_PARAM(poly_gamma)
+# endif
+
+# ifndef sph_viscosity_alpha
+  READ_NUMERIC_PARAM(sph_viscosity_alpha)
+# endif
+
+# ifndef sph_viscosity_beta
+  READ_NUMERIC_PARAM(sph_viscosity_beta)
+# endif
+
+# ifndef sph_viscosity_beta
+  READ_NUMERIC_PARAM(sph_viscosity_eta)
 # endif
 
   // specific apps  ---------------------------------------------------------

--- a/include/params.h
+++ b/include/params.h
@@ -139,6 +139,11 @@ namespace param {
   DECLARE_PARAM(int64_t,nparticles,1000)
 #endif
 
+//- square root of the total number of particles (for 2D setups)
+#ifndef sqrt_nparticles
+  DECLARE_PARAM(int64_t,sqrt_nparticles,100)
+#endif
+
 //- SPH eta parameter, eta = h (rho/m)^1/D (Rosswog'09, eq.51)
 #ifndef sph_eta
   DECLARE_PARAM(double,sph_eta,1.5)
@@ -297,6 +302,10 @@ void set_param(const std::string& param_name,
   // particle number and density --------------------------------------------
 # ifndef nparticles
   READ_NUMERIC_PARAM(nparticles)
+# endif
+
+# ifndef sqrt_nparticles
+  READ_NUMERIC_PARAM(sqrt_nparticles)
 # endif
 
 # ifndef sph_eta

--- a/include/params.h
+++ b/include/params.h
@@ -256,6 +256,17 @@ namespace param {
   DECLARE_PARAM(double,uint_initial,1.0)
 # endif
 
+// in Sedov test: total injected blast enregy
+# ifndef sedov_blast_energy
+  DECLARE_PARAM(double,sedov_blast_energy,1.0)
+# endif
+
+// in Sedov test: radius of energy injection
+// (in units of particle separation)
+# ifndef sedov_blast_radius
+  DECLARE_PARAM(double,sedov_blast_radius,1.0)
+# endif
+
 // ---
 
 /*!
@@ -406,6 +417,14 @@ void set_param(const std::string& param_name,
 
 # ifndef uint_initial
   READ_NUMERIC_PARAM(uint_initial)
+# endif
+
+# ifndef sedov_blast_energy
+  READ_NUMERIC_PARAM(sedov_blast_energy)
+# endif
+
+# ifndef sedov_blast_radius
+  READ_NUMERIC_PARAM(sedov_blast_radius)
 # endif
 
   // unknown parameter -------------------------------

--- a/include/params.h
+++ b/include/params.h
@@ -1,0 +1,201 @@
+/*~--------------------------------------------------------------------------~*
+ * Copyright (c) 2017 Los Alamos National Security, LLC
+ * All rights reserved.
+ *~--------------------------------------------------------------------------~*/
+
+ /*~--------------------------------------------------------------------------~*
+ * 
+ * /@@@@@@@@  @@           @@@@@@   @@@@@@@@ @@@@@@@  @@      @@
+ * /@@/////  /@@          @@////@@ @@////// /@@////@@/@@     /@@
+ * /@@       /@@  @@@@@  @@    // /@@       /@@   /@@/@@     /@@
+ * /@@@@@@@  /@@ @@///@@/@@       /@@@@@@@@@/@@@@@@@ /@@@@@@@@@@
+ * /@@////   /@@/@@@@@@@/@@       ////////@@/@@////  /@@//////@@
+ * /@@       /@@/@@//// //@@    @@       /@@/@@      /@@     /@@
+ * /@@       @@@//@@@@@@ //@@@@@@  @@@@@@@@ /@@      /@@     /@@
+ * //       ///  //////   //////  ////////  //       //      //  
+ *
+ *~--------------------------------------------------------------------------~*/
+
+/**
+ * @file params.h
+ * @author Oleg Korobkin
+ * @date June 2018
+ * @brief Handle global parameters: parsing parameter files, default vals etc. 
+ */
+
+#include <iostream>
+#include <fstream>
+#include <string>
+#include <string.h>
+#include <sstream>
+#include <stdlib.h>
+#include <assert.h>
+
+#define MAXLEN_FNAME 255
+
+namespace param {
+
+  // --- list of global parameters ------------------------------------------
+  int64_t nparticles;        //< global number of particles
+  int    sodtest_num;        //< Sod test number (1..5)
+  double poly_gamma;         //< polytropic index
+  double initial_dt;         //< intial timestep
+  char   initial_data_h5part[MAXLEN_FNAME]; //< h5part output filename
+  // ---
+
+/*!
+   trim whitespace from the begging and end of line
+ */
+std::string trim(const std::string& str) {
+  using namespace std;
+  const size_t strBegin = str.find_first_not_of(" \t");
+  if (strBegin == string::npos)
+    return "";
+  const size_t strEnd = str.find_last_not_of(" \t");
+  return str.substr(strBegin, strEnd - strBegin + 1);
+}
+
+
+/*!
+   setup global defaults
+ */
+void set_default_params(int rank, int size) {
+  nparticles = 1000;
+  poly_gamma = 1.4;
+  sodtest_num = 1;
+  initial_dt = 1.0;
+  sprintf(initial_data_h5part,"%s","init.h5part");
+}
+
+
+/**
+ * @brief Sets a global parameter param_name to the value, given by its
+ *        string representation param_value
+ */
+void set_param(const std::string& param_name,
+               const std::string& param_value) {
+  using namespace std;
+  bool run_job;
+
+  // strip trailing comments
+  size_t i2 = param_value.find("#");
+  string str_value;
+  if (i2 != string::npos) 
+    str_value = trim(param_value.substr(0,i2));
+  else
+    str_value = param_value;
+
+  // remove (single or double) quotes 
+  if (str_value[0]=='\'' or str_value[0]=='\"') 
+    str_value = str_value.substr(1,str_value.length()-2);
+  istringstream iss(str_value);
+
+  // boolean parameters ------------------------------
+  bool lparam_value = (str_value == "yes" 
+                    or str_value == "'yes'" 
+                    or str_value == "\"yes\"");
+  if (param_name == "run_job") {
+    run_job = lparam_value;
+  }
+ 
+  // integer parameters ------------------------------
+  else if (param_name == "nparticles") {
+    iss >> nparticles;
+  }
+  else if (param_name == "sodtest_num") {
+    iss >> sodtest_num;
+  }
+
+  // real parameters ---------------------------------
+  else if (param_name == "poly_gamma") {
+    iss >> poly_gamma;
+  }
+  else if (param_name == "intial_dt") {
+    iss >> initial_dt;
+  }
+
+  // string parameters -------------------------------
+  else if (param_name == "initial_data_h5part") {
+    strcpy(initial_data_h5part, str_value.c_str());
+  }
+  // unknown parameter -------------------------------
+  else { 
+    clog_one(fatal) << "ERROR: unknown parameter " << param_name << endl;
+    exit(2);
+  }
+ 
+  clog_one(trace) << param_name << ": " << param_value << endl;
+}               
+
+/**
+ * @brief Parameter file parser
+ *
+ * Simulation parameter file contains strings of pairs:
+ *  param = value
+ *
+ * assigining values to specific parameters. Parameters can have four 
+ * different types: logical (boolean), integer, real and string. 
+ * Parameter file can contain comments. Comments begin with '#'; 
+ * everything after '#' is ignored. Strings can be embraced in single 
+ * quotes (') or double quotes ("). Logical parameters are initialized 
+ * with "yes" or "no".
+ *
+ * Example of a parameter file snippet:
+ * --->>> sodtube_N100.par ---------------
+  # Sodtube test #1 for 100 particles
+  nparticles= 1000    # global number of particles
+  poly_gamma = 1.4    # polytropic index
+  sodtest_num  = 1    # which Sod test to generate
+  output_singlefile = yes
+  intial_data_h5part  = "hdf5_sodtube.h5part"
+ * ---<<<  --------------------------------
+ */
+void read_params(std::string parfile) {
+  using namespace std;
+  ifstream infile;
+  string line;
+  infile.open(parfile.c_str());
+  if (!infile) {
+    cerr << "ERROR: Unable to open file " << parfile << endl;
+    exit(1);
+  }
+
+  for (int ln=1; std::getline(infile,line); ++ln) {
+
+    // skip comments (lines starting with '#' at any position)
+    // and blank lines
+    bool is_blank = true, is_comment = false;
+    for (int i=0;i<line.length();i++) {
+      char c = line[i];
+      is_comment = (c == '#');
+      is_blank = (c == ' ' || c == '\t');
+      if (is_comment or not is_blank) break;
+    }
+    if (is_comment or is_blank) continue;
+
+    // line must be in the form:
+    // lhs = rhs
+    size_t eqpos = line.find("=");
+    if (eqpos == string::npos) {
+      cerr << "ERROR in parameter file " << parfile
+           << ", line #" << ln << endl;
+      exit(1);
+    }
+    string lhs = line.substr(0,eqpos);
+    string rhs = line.substr(eqpos+1);
+
+    // strip whitespace
+    lhs = trim(lhs);
+    rhs = trim(rhs);
+    if (lhs.length() == 0 or rhs.length() == 0) {
+      cerr << "ERROR in parameter file " << parfile
+           << ", line #" << ln << ": wrong format" << endl;
+      exit(1);
+    }
+    set_param(lhs,rhs);
+  }
+  infile.close();
+}
+
+} // namespace params
+

--- a/include/physics/analysis.h
+++ b/include/physics/analysis.h
@@ -23,10 +23,11 @@
  * @brief Basic analysis
  */
 
-#ifndef _physics_analysis_h_
-#define _physics_analysis_h_
+#ifndef _PHYSICS_ANALYSIS_H_
+#define _PHYSICS_ANALYSIS_H_
 
 #include <vector>
+#include "params.h"
 
 //#include "physics.h"
 
@@ -74,13 +75,17 @@ namespace analysis{
   void
   screen_output() 
   {
+    using namespace param;
+    static int count = 0;
     const int screen_length = 40;  
-    (physics::iteration-1)%screen_length  ||
-    clog_one(info)<< "#-- iteration:               time:" <<std::endl;
-    clog_one(info)
-      << std::setw(14) << physics::iteration
-      << std::setw(20) << std::scientific << std::setprecision(12)
-      << physics::totaltime << std::endl;
+    if (out_screen_every > 0 || physics::iteration % out_screen_every == 0) {
+      (++count-1)%screen_length  ||
+      clog_one(info)<< "#-- iteration:               time:" <<std::endl;
+      clog_one(info)
+        << std::setw(14) << physics::iteration
+        << std::setw(20) << std::scientific << std::setprecision(12)
+        << physics::totaltime << std::endl;
+    }
   }
 
 
@@ -155,4 +160,4 @@ namespace analysis{
 
 }; // physics
 
-#endif // _physics_analysis_h_
+#endif // _PHYSICS_ANALYSIS_H_

--- a/include/physics/analysis.h
+++ b/include/physics/analysis.h
@@ -144,7 +144,7 @@ namespace analysis{
     oss_data << std::setw(14) << physics::iteration
       << std::setw(20) << std::scientific << std::setprecision(12)
       << physics::totaltime << std::setw(20) << total_mass;
-    for(int i = 0 ; i < gdimension ; ++i){
+    for(size_t i = 0 ; i < gdimension ; ++i){
       oss_data
         << std::setw(20) << std::scientific << std::setprecision(12)
         << linear_momentum[i] <<" ";

--- a/include/physics/body.h
+++ b/include/physics/body.h
@@ -93,7 +93,7 @@ public:
 
   point_t getLinMomentum() const { 
     point_t res = {};
-    for(int i = 0 ; i < dimension; ++i){
+    for(size_t i = 0 ; i < dimension; ++i){
       res[i] = velocity_[i] * mass_;
     }
     return res;

--- a/include/physics/default_physics.h
+++ b/include/physics/default_physics.h
@@ -28,6 +28,7 @@
 
 #include <vector>
 
+#include "params.h"
 #include "utils.h"
 #include "kernels.h"
 #include "tree.h"
@@ -48,7 +49,6 @@ namespace physics{
   double dt = 0.0;
   double alpha = 2; 
   double beta = 2; 
-  double gamma = 1.4;
   double epsilon = 0.01;
   double damp = 1;
   double totaltime = 0.0;
@@ -94,8 +94,9 @@ namespace physics{
   compute_pressure(
       body_holder* srch)
   { 
+    using namespace param;
     body* source = srch->getBody();
-    double pressure = (gamma-1.0)*
+    double pressure = (poly_gamma-1.0)*
       source->getDensity()*source->getInternalenergy();
     source->setPressure(pressure);
   } // compute_pressure
@@ -110,9 +111,10 @@ namespace physics{
   compute_pressure_adiabatic(
       body_holder* srch)
   { 
+    using namespace param;
     body* source = srch->getBody();
     double pressure = source->getAdiabatic()*
-      pow(source->getDensity(),gamma);
+      pow(source->getDensity(),poly_gamma);
     source->setPressure(pressure);
   } // compute_pressure
 #endif 
@@ -148,8 +150,10 @@ namespace physics{
   compute_soundspeed(
       body_holder* srch)
   {
+    using namespace param;
     body* source = srch->getBody();
-    double soundspeed = sqrt(gamma*source->getPressure()/source->getDensity());
+    double soundspeed = sqrt(poly_gamma*source->getPressure()
+                                       /source->getDensity());
     source->setSoundspeed(soundspeed);
   } // computeSoundspeed
 
@@ -360,6 +364,7 @@ namespace physics{
     body_holder* srch, 
     std::vector<body_holder*>& ngbsh)
   { 
+    using namespace param;
     body* source = srch->getBody();
     
     // Compute the adiabatic factor here 
@@ -398,7 +403,8 @@ namespace physics{
         );
     }
     
-    dadt *= (gamma - 1)/(2*pow(source->getDensity(),gamma-1));
+    dadt *= (poly_gamma - 1) / 
+            (2*pow(source->getDensity(),poly_gamma-1));
     source->setDadt(dadt);
  
 

--- a/include/physics/default_physics.h
+++ b/include/physics/default_physics.h
@@ -34,6 +34,7 @@
 #include "tree.h"
 
 namespace physics{
+  using namespace param;
 
   /**
    * Default values
@@ -41,9 +42,6 @@ namespace physics{
    * to be application-specific. 
    * \TODO add a parameter file to be read in the main_driver
    */
-  bool do_boundaries = false;
-  bool stop_boundaries = false; 
-  bool reflect_boundaries = false;
   point_t max_boundary = {};
   point_t min_boundary = {};
   double dt = 0.0;

--- a/include/physics/default_physics.h
+++ b/include/physics/default_physics.h
@@ -457,7 +457,7 @@ namespace physics{
 
     if(stop_boundaries){
       bool stop = false; 
-      for(int i = 0; i < gdimension; ++i){
+      for(size_t i = 0; i < gdimension; ++i){
         if(position[i] < min_boundary[i] ||
           position[i] > max_boundary[i]){
           stop = true; 

--- a/include/physics/kernels.h
+++ b/include/physics/kernels.h
@@ -43,7 +43,7 @@ namespace kernels{
   double vector_size(
     point_t& p){
     double result = 0.;
-    for(int i = 0 ; i < gdimension; ++i){
+    for(size_t i = 0 ; i < gdimension; ++i){
       result += p[i]*p[i];
     }
     return sqrt(result);

--- a/include/physics/specific/BNS_physics.h
+++ b/include/physics/specific/BNS_physics.h
@@ -28,6 +28,7 @@
 
 #include <vector>
 
+#include "params.h"
 #include "kernels.h"
 #include "tree.h"
 
@@ -94,9 +95,10 @@ namespace physics{
   compute_internal_energy_from_adiabatic(
     body_holder* srch)
   {
+    using namespace param;
     body* source = srch->getBody();
-    double u = source->getAdiabatic()/(gamma-1)*
-      pow(source->getDensity(),gamma-1);
+    double u = source->getAdiabatic()/(poly_gamma-1)*
+      pow(source->getDensity(),poly_gamma-1);
     source->setInternalenergy(u);
   }
 
@@ -105,9 +107,10 @@ namespace physics{
   compute_adiabatic_from_internal_energy(
     body_holder* srch)
   {
+    using namespace param;
     body* source = srch->getBody();
-    double A = (gamma-1)*source->getInternalenergy()/
-      pow(source->getDensity(),gamma-1);
+    double A = (poly_gamma-1)*source->getInternalenergy()/
+      pow(source->getDensity(),poly_gamma-1);
     source->setAdiabatic(A);
   }
 

--- a/mpisph/bodies_system.h
+++ b/mpisph/bodies_system.h
@@ -248,6 +248,7 @@ public:
     int rank, size;
     MPI_Comm_rank(MPI_COMM_WORLD,&rank);
     MPI_Comm_size(MPI_COMM_WORLD,&size);
+    std::ostringstream oss;
 
     // Destroy the previous tree
     if(tree_ !=  nullptr){
@@ -310,11 +311,12 @@ public:
       MPI_COMM_WORLD
       );
 
-    clog_one(trace)<<rank<<" sub_entities before="; 
+    oss << rank << " sub_entities before="; 
     for(auto v: nentities){
-      clog_one(trace)<<v<<";";
+      oss << v << ";";
     }
-    clog_one(trace)<<std::endl;
+    oss << std::endl;
+    clog_one(trace) << oss.str() << std::flush;
 #endif
 
     // Exchnage usefull body_holder from my tree to other processes
@@ -338,11 +340,12 @@ public:
       MPI_COMM_WORLD
       );
 
-    clog_one(trace)<<rank<<" sub_entities after="; 
+    oss << rank << " sub_entities after="; 
     for(auto v: nentities){
-      clog_one(trace)<<v<<";";
+      oss << v << ";";
     }
-    clog_one(trace)<<std::endl;
+    oss << std::endl;
+    clog_one(trace) << oss.str() << std::flush;
 #endif
     
     tcolorer_.mpi_compute_ghosts(*tree_,bodies_,smoothinglength_/*,range_*/);

--- a/mpisph/bodies_system.h
+++ b/mpisph/bodies_system.h
@@ -133,7 +133,7 @@ public:
   void 
   read_bodies(
       const char * filename,
-      int startiteration)
+      const int startiteration)
   {
 
     io::inputDataHDF5(localbodies_,filename,totalnbodies_,localnbodies_,


### PR DESCRIPTION
This branch introduces global parameters, specified and read from a separate text file. So far implemented for sodtube, sedov and noh only. For each problem, generator and evolution solver use the same parameter file. Sample parameter files are placed in test/ subdirectories for each of the apps.
Usage example:
cd build/app/sodtube
cp ../../../app/sodtube/test/sodtube_t1n100.par .
./sodtube_generator sodtube_t1n100.par
mpirun -np 4 ./sodtube sodtube_t1n100.par
We need to discuss how to use this better in the context of FleCSI, because other group is working on making this easier for us...
