### PR TITLE
Fix/oleg/renaming

### DIFF
--- a/app/drivers/hydro/main_driver.cc
+++ b/app/drivers/hydro/main_driver.cc
@@ -207,10 +207,10 @@ mpi_init_task(const char * parameter_file){
       rank|| clog(trace) << ".done" << std::endl;
     }
 
-    if(variable_smoothinglength){
+    if(sph_update_uniform_h){
       // The particles moved, compute new smoothing length 
-      rank || clog(trace) << "smoothing length: computation"<<std::flush;
-      bs.get_all(physics::compute_smoothinglength,bs.getNBodies());
+      rank || clog(trace) << "updating smoothing length"<<std::flush;
+      bs.get_all(physics::compute_average_smoothinglength,bs.getNBodies());
       rank || clog(trace) << ".done" << std::endl << std::flush;
     }
 

--- a/data/sedov_sqn100.par
+++ b/data/sedov_sqn100.par
@@ -22,4 +22,3 @@
   out_scalar_every = 10
   out_h5data_every = 10
   output_h5data_prefix = "sedov_evolution"
-  variable_smoothinglength=true

--- a/include/params.h
+++ b/include/params.h
@@ -175,6 +175,12 @@ namespace param {
   DECLARE_PARAM(double,sph_sinc_index,4.0)
 #endif
 
+//- if true, recompute (uniform) smoothing length every timestep 
+//  h = average { sph_eta (m/rho)^1/D } (Rosswog'09, eq.51)
+# ifndef sph_update_uniform_h
+  DECLARE_PARAM(bool, sph_update_uniform_h,false)
+# endif 
+
 //
 // Geometric parameters
 //
@@ -366,10 +372,6 @@ namespace param {
   DECLARE_PARAM(double,flow_velocity,0.0)
 # endif
 
-# ifndef variable_smoothinglength 
-  DECLARE_PARAM(bool, variable_smoothinglength,false)
-# endif 
-
 //
 // Airfoil parameters
 //
@@ -498,6 +500,10 @@ void set_param(const std::string& param_name,
 # ifndef sph_sinc_index
   READ_NUMERIC_PARAM(sph_sinc_index)
 # endif
+
+# ifndef sph_update_uniform_h
+  READ_BOOLEAN_PARAM(sph_update_uniform_h)
+# endif 
 
   // geometric configuration  -----------------------------------------------
 # ifndef box_length
@@ -641,10 +647,6 @@ void set_param(const std::string& param_name,
 # ifndef flow_velocity
   READ_NUMERIC_PARAM(flow_velocity)
 # endif
-
-# ifndef variable_smoothinglength
-  READ_BOOLEAN_PARAM(variable_smoothinglength)
-# endif 
 
   // airfoil parameters  ----------------------------------------------------
 # ifndef airfoil_size

--- a/include/physics/default_physics.h
+++ b/include/physics/default_physics.h
@@ -687,30 +687,28 @@ namespace physics{
   }
 
   /**
-   * @ brief compute new smoothing length for particles
-   * ha = 1/N \sum_b pow(m_b / rho_b,1/dimension)
+   * @brief update smoothing length for particles (Rosswog'09, eq.51)
+   * 
+   * ha = eta/N \sum_b pow(m_b / rho_b,1/dimension)
    */
   void
-  compute_smoothinglength(
+  compute_average_smoothinglength(
       std::vector<body_holder*>& bodies,
       int64_t nparticles)
   {
-    std::cout<<" h="<<bodies[0]->getBody()->getSmoothinglength()<<std::endl;
     // Compute the total 
     double total = 0.;
-    for(auto b: bodies)
-    {
+    for(auto b: bodies) {
       total += pow(b->getBody()->getMass()/b->getBody()->getDensity(),
           1./(double)gdimension);
     }
     // Add up with all the processes 
     MPI_Allreduce(MPI_IN_PLACE,&total,1,MPI_DOUBLE,MPI_SUM,MPI_COMM_WORLD);
     // Compute the new smoothing length 
-    double new_h = 1./(double)nparticles * total;
+    double new_h = sph_eta/(double)nparticles * total;
     for(auto b: bodies) { 
       b->getBody()->setSmoothinglength(new_h);
     }
-    std::cout<<" nh="<<bodies[0]->getBody()->getSmoothinglength()<<std::endl;
   }
   
 


### PR DESCRIPTION
A few minor fixes:
 - added multiplication of "sph_eta" when computing smoothing length (see Rosswog'09, eq.51)
 - renamed "variable_smoothinglength" -> "sph_update_uniform_h". This is more descriptive, because "variable" should be reserved for "spatially-variable", i.e. non-uniform. 
 - renamed "compute_smoothinglength" -> "compute_average_smoothinglength".
 - turned off new parameter in sedov_sqn100.par: I am not sure it is good there, because density in the center becomes really low and correspondingly smoothing length will grow to unacceptably large values, smearing the shock.