### PR TITLE
(-) commented out linking against tabulated EoS libraries

### DIFF
--- a/app/drivers/CMakeLists.txt
+++ b/app/drivers/CMakeLists.txt
@@ -69,8 +69,9 @@ add_executable(newtonian_3d
   ${FleCSI_RUNTIME}/runtime_driver.cc
 )
 target_link_libraries(newtonian_3d ${FleCSPH_LIBRARIES})
-target_link_libraries(newtonian_3d ${CMAKE_SOURCE_DIR}/third-party-libraries/stellar_collapse/libTABEOS_RF.a)
-target_link_libraries(newtonian_3d ${CMAKE_SOURCE_DIR}/third-party-libraries/stellar_collapse/libTABEOS_SC.a)
+#### THESE ARE NOT BUILT PROPERLY as of now -- commenting them out (2018-10-05, O.K.)
+# target_link_libraries(newtonian_3d ${CMAKE_SOURCE_DIR}/third-party-libraries/stellar_collapse/libTABEOS_RF.a)
+# target_link_libraries(newtonian_3d ${CMAKE_SOURCE_DIR}/third-party-libraries/stellar_collapse/libTABEOS_SC.a)
 target_compile_definitions(newtonian_3d PUBLIC -DEXT_GDIMENSION=3)
 
 #------------------------------------------------------------------------------#


### PR DESCRIPTION
The linking of tabulated EoS is not working at the moment: before this is fixed, I am
commenting them out in the CMakeLists.txt