### PR TITLE
Fix/oleg/sedov test

### DIFF
--- a/app/drivers/CMakeLists.txt
+++ b/app/drivers/CMakeLists.txt
@@ -113,7 +113,7 @@ cinch_add_unit(sedov_test
     hydro/main_driver.cc
     ${FleCSI_RUNTIME}/runtime_driver.cc 
   INPUTS
-    ${PROJECT_SOURCE_DIR}/data/sedov_sqn100.par 
+    ${PROJECT_SOURCE_DIR}/data/sedov_nx20.par 
   LIBRARIES 
     ${FleCSPH_LIBRARIES}
   DEFINES
@@ -124,8 +124,8 @@ cinch_add_unit(sedov_test
 if(ENABLE_UNIT_TESTS)
 add_custom_target(
     sedov_2d_generator_test 
-    COMMAND mpirun -n 1 ../id_generators/sedov_2d_generator ${PROJECT_SOURCE_DIR}/data/sedov_sqn100.par
-    COMMAND mv sedov_sqn100.h5part ../../test/drivers
+    COMMAND mpirun -n 1 ../id_generators/sedov_2d_generator ${PROJECT_SOURCE_DIR}/data/sedov_nx20.par
+    COMMAND mv sedov_nx20.h5part ../../test/drivers
     DEPENDS ../id_generators/sedov_2d_generator
 )
 add_dependencies(sedov_test sedov_2d_generator_test)

--- a/app/drivers/test/sedov.cc
+++ b/app/drivers/test/sedov.cc
@@ -17,6 +17,6 @@ using namespace execution;
 
 TEST(sedov, working) {
   //MPI_Init(NULL,NULL);
-  mpi_init_task("sedov_sqn100.par");
+  mpi_init_task("sedov_nx20.par");
   //MPI_Finalize();
 }

--- a/app/id_generators/sedov/main.cc
+++ b/app/id_generators/sedov/main.cc
@@ -14,6 +14,9 @@
 #include "hdf5ParticleIO.h"
 #include "lattice.h"
 
+#define SQ(x) ((x)*(x))
+#define CU(x) ((x)*(x)*(x))
+
 /*
 The Sedov test is set up with uniform density and vanishingly small pressure.
 An explosion is initialized via a point-like deposition of energy E_blast in
@@ -52,35 +55,80 @@ void print_usage() {
 //
 // derived parameters
 //
-static double r_blast;       // Radius of injection region
-static double total_mass;    // total mass of the fluid
-static double particle_mass; // mass of an individual particle
+static double timestep = 1.0;         // Recommended timestep
+static double r_blast = 0.;           // Radius of injection region
+static double total_mass = 1.;        // total mass of the fluid
+static double mass_particle = 1.;     // mass of an individual particle
+static point_t bbox_max, bbox_min;    // bounding box of the domain
 static std::string initial_data_file; // = initial_data_prefix + ".h5part"
 
 void set_derived_params() {
   using namespace param;
 
-  // total number of particles
-  total_mass = box_length*box_width*rho_initial;
-  if (gdimension == 2) {
-    SET_PARAM(nparticles, lattice_nx*lattice_nx);
-    if (domain_type == 1) // a circle
-      total_mass = rho_initial*M_PI*sphere_radius*sphere_radius;
-  } 
-  else {
-    SET_PARAM(nparticles, lattice_nx*lattice_nx*lattice_nx);
-    total_mass *= box_height;
-    if (domain_type == 1) // a sphere
-      total_mass = rho_initial*4./3.*M_PI 
-                              *sphere_radius*sphere_radius*sphere_radius;
-  }
-  particle_mass = total_mass / nparticles;
-  SET_PARAM(sph_smoothing_length, 
-           (sph_eta*pow(particle_mass/rho_initial,1./gdimension)));
+  particle_lattice::select();
 
+  // The value for constant timestep
+  timestep = initial_dt;
+
+  // Bounding box of the domain
+  if (domain_type == 0) { // box
+    bbox_min[0] = -box_length/2.;
+    bbox_max[0] =  box_length/2.;
+    bbox_min[1] = -box_width/2.;
+    bbox_max[1] =  box_width/2.;
+    if (gdimension == 3) {
+      bbox_min[2] = -box_height/2.;
+      bbox_max[2] =  box_height/2.;
+    }
+  }
+  else if (domain_type == 1) { // sphere or circle
+    bbox_min = -sphere_radius;
+    bbox_max =  sphere_radius;
+  }
+
+  // particle separation
+  if (domain_type == 0) {
+    SET_PARAM(sph_separation, (box_length/(lattice_nx-1)));
+  }
+  else if (domain_type == 1) {
+    SET_PARAM(sph_separation, (2.*sphere_radius/(lattice_nx-1)));
+  }
+
+  // Count number of particles
+  int64_t tparticles =
+      particle_lattice::count(lattice_type,domain_type,
+      bbox_min,bbox_max,sph_separation,0);
+  SET_PARAM(nparticles, tparticles);
+
+  // total mass
+  if (gdimension == 2) {
+    if (domain_type == 0) // a box
+      total_mass = rho_initial * box_length*box_width;
+    else if (domain_type == 1) // a circle
+      total_mass = rho_initial * M_PI*SQ(sphere_radius);
+  }
+  else if (gdimension == 3) {
+    if (domain_type == 0) // a box
+      total_mass = rho_initial * box_length*box_width*box_height;
+    else if (domain_type == 1) // a sphere
+      total_mass = rho_initial * 4./3.*M_PI*CU(sphere_radius);
+  }
+  else
+    assert (false);
+
+  // single particle mass
+  assert (equal_mass);
+  mass_particle = total_mass / nparticles;
+
+  // snoozing length
+  SET_PARAM(sph_smoothing_length,
+           (sph_eta*pow(mass_particle/rho_initial,1./gdimension)));
+
+  // intial internal energy
   SET_PARAM(uint_initial, (pressure_initial/(rho_initial*(poly_gamma-1.0))));
-  SET_PARAM(sph_separation, (2.*sphere_radius/(lattice_nx-1)));
-  r_blast = sedov_blast_radius * sph_separation;   // Radius of injection region
+
+  // Radius of injection region
+  r_blast = sedov_blast_radius * sph_separation;
 
   // file to be generated
   std::ostringstream oss;
@@ -113,59 +161,40 @@ int main(int argc, char * argv[]){
   param::mpi_read_params(argv[1]);
   set_derived_params();
 
-  particle_lattice::select();
-
-  // Header data
-  // the number of particles = nparticles
-  // The value for constant timestep
-  double timestep = initial_dt;
-  const point_t bbox_max =  sphere_radius;
-  const point_t bbox_min = -sphere_radius;
-
-  // Central coordinates: in most cases this should be centered at (0,0,0)
-  double x_c = 0.0;
-  double y_c = 0.0;
-  double z_c = 0.0;
-
-  // Count number of particles
-  int64_t tparticles = 
-      particle_lattice::count(lattice_type,domain_type,
-      bbox_min,bbox_max,sph_separation,0); 
-
   // Initialize the arrays to be filled later
   // Position
-  double* x = new double[tparticles]();
-  double* y = new double[tparticles]();
-  double* z = new double[tparticles]();
+  double* x = new double[nparticles]();
+  double* y = new double[nparticles]();
+  double* z = new double[nparticles]();
   // Velocity
-  double* vx = new double[tparticles]();
-  double* vy = new double[tparticles]();
-  double* vz = new double[tparticles]();
+  double* vx = new double[nparticles]();
+  double* vy = new double[nparticles]();
+  double* vz = new double[nparticles]();
   // Acceleration
-  double* ax = new double[tparticles]();
-  double* ay = new double[tparticles]();
-  double* az = new double[tparticles]();
+  double* ax = new double[nparticles]();
+  double* ay = new double[nparticles]();
+  double* az = new double[nparticles]();
   // Smoothing length
-  double* h = new double[tparticles]();
+  double* h = new double[nparticles]();
   // Density
-  double* rho = new double[tparticles]();
+  double* rho = new double[nparticles]();
   // Internal Energy
-  double* u = new double[tparticles]();
+  double* u = new double[nparticles]();
   // Pressure
-  double* P = new double[tparticles]();
+  double* P = new double[nparticles]();
   // Mass
-  double* m = new double[tparticles]();
+  double* m = new double[nparticles]();
   // Id
-  int64_t* id = new int64_t[tparticles]();
+  int64_t* id = new int64_t[nparticles]();
   // Timestep
-  double* dt = new double[tparticles]();
+  double* dt = new double[nparticles]();
 
   // Generate the lattice
-  assert(tparticles ==
+  assert(nparticles ==
       particle_lattice::generate(lattice_type,domain_type,
       bbox_min,bbox_max,sph_separation,0, x, y, z));
 
-  // particle id number
+  // Particle id number
   int64_t posid = 0;
 
   // Number of particles in the blast zone
@@ -173,42 +202,32 @@ int main(int argc, char * argv[]){
 
   // Total mass of particles in the blast zone
   double mass_blast = 0;
-  double mass;
-  if(gdimension==2){
-    mass = rho_initial * M_PI*pow(sphere_radius,2.)/tparticles;
-  } else{
-    mass = rho_initial * 4./3.*M_PI*pow(sphere_radius,3.)/tparticles;
-  }
+
+  // Count the number of particles and mass in the blast zone
+  // The blast is centered at the origin ({0,0} or {0,0,0})
+  for(int64_t part=0; part<nparticles; ++part)
+    if (SQ(x[part]) + SQ(y[part]) + SQ(z[part]) < SQ(r_blast)) {
+       particles_blast++;
+       mass_blast += mass_particle;
+    }
+
   // Assign density, pressure and specific internal energy to particles,
   // including the particles in the blast zone
-  for(int64_t part=0; part<tparticles; ++part){
-    // Particle mass from number of particles and density
-    m[part] = mass;
-
-    // Count particles in the blast zone and sum their masses
-    if (  (x[part]-x_c)*(x[part]-x_c) 
-        + (y[part]-y_c)*(y[part]-y_c)
-        + (z[part]-z_c)*(z[part]-z_c) < r_blast*r_blast) {
-       particles_blast++;
-       mass_blast += m[part];
-    }
-  }
-  for(int64_t part=0; part<tparticles; ++part){
+  for(int64_t part=0; part<nparticles; ++part){
+    m[part] = mass_particle;
     P[part] = pressure_initial;
     rho[part] = rho_initial;
     u[part] = uint_initial;
     h[part] = sph_smoothing_length;
     id[part] = posid++;
 
-    if (  (x[part]-x_c)*(x[part]-x_c) 
-        + (y[part]-y_c)*(y[part]-y_c)
-        + (z[part]-z_c)*(z[part]-z_c) < r_blast*r_blast) {
+    if (SQ(x[part]) + SQ(y[part]) + SQ(z[part]) < SQ(r_blast)) {
        u[part] = u[part] + sedov_blast_energy/particles_blast;
        P[part] = u[part]*rho[part]*(poly_gamma - 1.0);
     }
   }
 
-  clog(info) << "Real number of particles: " << tparticles << std::endl;
+  clog(info) << "Number of particles: " << nparticles << std::endl;
   clog(info) << "Total number of seeded blast particles: " << particles_blast << std::endl;
   clog(info) << "Total blast energy (E_blast = u_blast * total mass): "
                  << sedov_blast_energy * mass_blast << std::endl;
@@ -220,7 +239,7 @@ int main(int argc, char * argv[]){
   testDataSet.createDataset(initial_data_file.c_str(),MPI_COMM_WORLD);
 
   // add the global attributes
-  testDataSet.writeDatasetAttribute("nparticles","int64_t",tparticles);
+  testDataSet.writeDatasetAttribute("nparticles","int64_t",nparticles);
   testDataSet.writeDatasetAttribute("timestep","double",timestep);
   testDataSet.writeDatasetAttribute("dimension","int32_t",gdimension);
   testDataSet.writeDatasetAttribute("use_fixed_timestep","int32_t",1);
@@ -232,9 +251,9 @@ int main(int argc, char * argv[]){
 
   Flecsi_Sim_IO::Variable _d1,_d2,_d3;
 
-  _d1.createVariable("x",Flecsi_Sim_IO::point,"double",tparticles,x);
-  _d2.createVariable("y",Flecsi_Sim_IO::point,"double",tparticles,y);
-  _d3.createVariable("z",Flecsi_Sim_IO::point,"double",tparticles,z);
+  _d1.createVariable("x",Flecsi_Sim_IO::point,"double",nparticles,x);
+  _d2.createVariable("y",Flecsi_Sim_IO::point,"double",nparticles,y);
+  _d3.createVariable("z",Flecsi_Sim_IO::point,"double",nparticles,z);
 
   testDataSet.vars.push_back(_d1);
   testDataSet.vars.push_back(_d2);
@@ -242,9 +261,9 @@ int main(int argc, char * argv[]){
 
   testDataSet.writeVariables();
 
-  _d1.createVariable("vx",Flecsi_Sim_IO::point,"double",tparticles,vx);
-  _d2.createVariable("vy",Flecsi_Sim_IO::point,"double",tparticles,vy);
-  _d3.createVariable("vz",Flecsi_Sim_IO::point,"double",tparticles,vz);
+  _d1.createVariable("vx",Flecsi_Sim_IO::point,"double",nparticles,vx);
+  _d2.createVariable("vy",Flecsi_Sim_IO::point,"double",nparticles,vy);
+  _d3.createVariable("vz",Flecsi_Sim_IO::point,"double",nparticles,vz);
 
   testDataSet.vars.push_back(_d1);
   testDataSet.vars.push_back(_d2);
@@ -252,9 +271,9 @@ int main(int argc, char * argv[]){
 
   testDataSet.writeVariables();
 
-  _d1.createVariable("ax",Flecsi_Sim_IO::point,"double",tparticles,ax);
-  _d2.createVariable("ay",Flecsi_Sim_IO::point,"double",tparticles,ay);
-  _d3.createVariable("az",Flecsi_Sim_IO::point,"double",tparticles,az);
+  _d1.createVariable("ax",Flecsi_Sim_IO::point,"double",nparticles,ax);
+  _d2.createVariable("ay",Flecsi_Sim_IO::point,"double",nparticles,ay);
+  _d3.createVariable("az",Flecsi_Sim_IO::point,"double",nparticles,az);
 
   testDataSet.vars.push_back(_d1);
   testDataSet.vars.push_back(_d2);
@@ -263,9 +282,9 @@ int main(int argc, char * argv[]){
   testDataSet.writeVariables();
 
 
-  _d1.createVariable("h",Flecsi_Sim_IO::point,"double",tparticles,h);
-  _d2.createVariable("rho",Flecsi_Sim_IO::point,"double",tparticles,rho);
-  _d3.createVariable("u",Flecsi_Sim_IO::point,"double",tparticles,u);
+  _d1.createVariable("h",Flecsi_Sim_IO::point,"double",nparticles,h);
+  _d2.createVariable("rho",Flecsi_Sim_IO::point,"double",nparticles,rho);
+  _d3.createVariable("u",Flecsi_Sim_IO::point,"double",nparticles,u);
 
   testDataSet.vars.push_back(_d1);
   testDataSet.vars.push_back(_d2);
@@ -273,9 +292,9 @@ int main(int argc, char * argv[]){
 
   testDataSet.writeVariables();
 
-  _d1.createVariable("P",Flecsi_Sim_IO::point,"double",tparticles,P);
-  _d2.createVariable("m",Flecsi_Sim_IO::point,"double",tparticles,m);
-  _d3.createVariable("id",Flecsi_Sim_IO::point,"int64_t",tparticles,id);
+  _d1.createVariable("P",Flecsi_Sim_IO::point,"double",nparticles,P);
+  _d2.createVariable("m",Flecsi_Sim_IO::point,"double",nparticles,m);
+  _d3.createVariable("id",Flecsi_Sim_IO::point,"int64_t",nparticles,id);
 
   testDataSet.vars.push_back(_d1);
   testDataSet.vars.push_back(_d2);
@@ -305,3 +324,4 @@ int main(int argc, char * argv[]){
   MPI_Finalize();
   return 0;
 }
+

--- a/app/id_generators/sedov/main.cc
+++ b/app/id_generators/sedov/main.cc
@@ -13,6 +13,7 @@
 #include "params.h"
 #include "hdf5ParticleIO.h"
 #include "lattice.h"
+#include "kernels.h"
 
 #define SQ(x) ((x)*(x))
 #define CU(x) ((x)*(x)*(x))
@@ -120,9 +121,13 @@ void set_derived_params() {
   assert (equal_mass);
   mass_particle = total_mass / nparticles;
 
-  // snoozing length
-  SET_PARAM(sph_smoothing_length,
-           (sph_eta*pow(mass_particle/rho_initial,1./gdimension)));
+  // set kernel
+  kernels::select(sph_kernel);
+
+  // smoothing length
+  const double sph_h = sph_eta * kernels::kernel_width
+                               * pow(mass_particle/rho_initial,1./gdimension);
+  SET_PARAM(sph_smoothing_length, sph_h);
 
   // intial internal energy
   SET_PARAM(uint_initial, (pressure_initial/(rho_initial*(poly_gamma-1.0))));

--- a/data/sedov_nx20.par
+++ b/data/sedov_nx20.par
@@ -8,17 +8,21 @@
   rho_initial = 1.0
   pressure_initial = 1.0e-7
   sphere_radius = 1.0
-  sph_eta = 1.5
+  sph_eta = 1.2
   sedov_blast_energy = 1.0
   sedov_blast_radius = 1.0 # in units of particle separation
-  lattice_type = 0         # 0:rectangular, 1:hcp, 2:fcc
-  domain_type = 1          # 0:cube, 1:sphere, 2:full box
+  lattice_type = 2         # 0:rectangular, 1:hcp, 2:fcc
+  domain_type = 1          # 0:box, 1:sphere
+  # box_length = 1.0
+  # box_width  = 1.3
+  # box_height = 0.8
 
 # evolution parameters:
-  sph_kernel = "Quintic Spline"
-  initial_dt = 2.e-2  # TODO: better use Courant factor X sph_separation
+  sph_kernel = "quintic spline"
+  initial_dt = 2.e-3  # TODO: better use Courant factor X sph_separation
   final_iteration = 50
   out_screen_every = 1
   out_scalar_every = 10
   out_h5data_every = 10
   output_h5data_prefix = "sedov_evolution"
+  # sph_update_uniform_h = yes

--- a/data/sedov_nx20.par
+++ b/data/sedov_nx20.par
@@ -2,21 +2,21 @@
 # Sedov blast wave test
 #
 # initial data
-  initial_data_prefix = "sedov_sqn100"
-  lattice_nx = 100         # particle lattice dimension
+  initial_data_prefix = "sedov_nx20"
+  lattice_nx = 20          # particle lattice dimension
   poly_gamma = 1.4         # polytropic index
   rho_initial = 1.0
   pressure_initial = 1.0e-7
-  sph_separation = 0.001   # TODO: use sph_eta instead
-  #sph_eta = 1.5
+  sphere_radius = 1.0
+  sph_eta = 1.5
   sedov_blast_energy = 1.0
   sedov_blast_radius = 1.0 # in units of particle separation
-  lattice_type = 1         # 0:rectangular, 1:hcp, 2:fcc  **in 2d both hcp and fcc are triangular**
+  lattice_type = 0         # 0:rectangular, 1:hcp, 2:fcc
   domain_type = 1          # 0:cube, 1:sphere, 2:full box
 
 # evolution parameters:
   sph_kernel = "Quintic Spline"
-  initial_dt = 2.e-5  # TODO: better use Courant factor X sph_separation
+  initial_dt = 2.e-2  # TODO: better use Courant factor X sph_separation
   final_iteration = 50
   out_screen_every = 1
   out_scalar_every = 10

--- a/include/lattice.h
+++ b/include/lattice.h
@@ -32,19 +32,16 @@
  * Inputs:
  *  lattice_type - int value, corresponding to 0:rect, 1:HCP, 2:FCC (1 & 2 are
  *                 triangular in 2D)
- *  domain_type  - int value, 0:cube, 1:sphere, 2:full domain
- *  bbox_min     - bottom corner location for smallest cube covering the domain
- *  bbox_max     - top corner location for smallest cube covering the domain
- *  sph_sep      - the separation for the given domain within bbox_min and bbox_max
+ *  domain_type  - int value, 0:box, 1:sphere
+ *  bbox_min     - bounding box: bottom-left corner (or a bounding cube if domain)
+ *  bbox_max     - bounding box: top-right corner   (is spherical                )
+ *  sph_sep      - particle separation within the lattice
  *  posid        - enter the particle ID number from which the function is called
  *                 it is important for when the function is assigning position
  *                 coordinates to the particles
  *  count_only   - boolean for determing particle number (returned for allocating
  *                 proper arrays) or writing positions to those arrays
  *  x,y,z[]      - the arrays to be filled for the positions of each particle
- *
- *
- * TODO: include variables for paralellization (mpi rank)
  */
 
 #include <stdlib.h>
@@ -60,77 +57,44 @@ namespace particle_lattice {
  *             Returns boolean: true or false
  *
  * @param      x,y,z       - position of the particle
- *             x0,y0,z0    - position of the center of the domain (relevant for
- *                           spheres and cubes)
  *             bbox_min    - minimum position for the total domain
  *             bbox_max    - maximum position for the total domain
- *             r           - radius of the sphere or 1/2 length of cube edge
- *             domain_type - int value, 0:cube, 1:sphere, 2:full domain
+ *             domain_type - int value, 0:cube, 1:sphere
  */
-bool in_domain_1d(
-    const double x,
-    const double x0,
-    const double xmin,
-    const double xmax,
-    const double r,
-    const int domain_type)
-{
-  // within_domain checks to see if the position is within the total domain
-  bool within_domain = (x>=xmin && x<=xmax);
-
-  // Check if within domain_type
-  if (domain_type == 0 || domain_type == 1)
-    within_domain *= (std::abs(x-x0)<=r);
-  return within_domain;
-}
-
-bool in_domain_2d(
-    const double x,
-    const double y,
-    const double x0,
-    const double y0,
-    const point_t& bbox_min,
-    const point_t& bbox_max,
-    const double r,
-    const int domain_type)
-{
-  // within_domain checks to see if the position is within the total domain
-  double xmin = bbox_min[0], xmax = bbox_max[0];
-  double ymin = bbox_min[1], ymax = bbox_max[1];
+bool in_domain_2d(const double x, const double y, 
+    const point_t& bbox_min, const point_t& bbox_max, const int domain_type) {
+  // within_domain checks to see if the position is within the bounding box
+  const double xmin = bbox_min[0], xmax = bbox_max[0],
+               ymin = bbox_min[1], ymax = bbox_max[1];
   bool within_domain = x>=xmin && x<=xmax && y>=ymin && y<=ymax;
 
-  // Check if within domain_type
-  if(domain_type==0)
-    within_domain &= (std::abs(x-x0)<=r && std::abs(y-y0)<=r);
-  else if(domain_type==1)
+  // extra check for a circular domain
+  if(domain_type==1) {
+    const double r = 0.5*std::min(xmax-xmin, ymax-ymin);
+    const double x0 = 0.5*(xmin + xmax);
+    const double y0 = 0.5*(ymin + ymax);
     within_domain &= ((x-x0)*(x-x0)+(y-y0)*(y-y0) <r*r);
+  }
   return within_domain;
 }
 
-bool in_domain_3d(
-    const double x,
-    const double y,
-    const double z,
-    const double x0,
-    const double y0,
-    const double z0,
-    const point_t& bbox_min,
-    const point_t& bbox_max,
-    const double r,
-    const int domain_type)
-{
+bool in_domain_3d(const double x, const double y, const double z,
+    const point_t& bbox_min, const point_t& bbox_max, const int domain_type) {
   // within_domain checks to see if the position is within the total domain
-  double xmin = bbox_min[0], xmax = bbox_max[0];
-  double ymin = bbox_min[1], ymax = bbox_max[1];
-  double zmin = bbox_min[2], zmax = bbox_max[2];
+  const double xmin = bbox_min[0], xmax = bbox_max[0],
+               ymin = bbox_min[1], ymax = bbox_max[1],
+               zmin = bbox_min[2], zmax = bbox_max[2];
   bool within_domain = 
        x>=xmin && x<=xmax && y>=ymin && y<=ymax && z>=zmin && z<=zmax;
 
-  // Check if within domain_type
-  if(domain_type==0)
-    within_domain &= (std::abs(x-x0)<=r && std::abs(y-y0)<=r && std::abs(z-z0)<=r);
-  else if(domain_type==1)
+  // extra check for a spherical domain
+  if(domain_type==1) {
+    const double r = 0.5*std::min(std::min(xmax-xmin,ymax-ymin),(zmax-zmin));
+    const double x0 = 0.5*(xmin + xmax);
+    const double y0 = 0.5*(ymin + ymax);
+    const double z0 = 0.5*(zmin + zmax);
     within_domain &= ((x-x0)*(x-x0)+(y-y0)*(y-y0)+(z-z0)*(z-z0) < r*r);
+  }
   return within_domain;
 }
 
@@ -154,12 +118,6 @@ int64_t generator_lattice_1d(
    double y[] = NULL,
    double z[] = NULL)
 {
-  // Determine radius of the domain as a radius of inscribed sphere
-  double radius = 0.0;
-  if(domain_type==1 || domain_type==0) {
-     radius = 0.5*(bbox_max[0] - bbox_min[0]);
-  }
-
   // Central coordinates: in most cases this should be centered at 0
   double x_c = (bbox_max[0] + bbox_min[0])/2.;
 
@@ -169,15 +127,13 @@ int64_t generator_lattice_1d(
   // regular lattice in 1D
   double xmin = bbox_min[0], xmax = bbox_max[0];
   for(double x_p = xmin; x_p < xmax; x_p += sph_sep){
-    if(in_domain_1d(x_p,x_c,xmin,xmax,radius,domain_type)){
-      tparticles++;
-      if(!count_only){
-        x[posid] = x_p;
-        y[posid] = 0.0;
-        z[posid] = 0.0;
-      }
-      posid++;
+    tparticles++;
+    if(!count_only){
+      x[posid] = x_p;
+      y[posid] = 0.0;
+      z[posid] = 0.0;
     }
+    posid++;
   }
   return tparticles;
 }
@@ -195,19 +151,6 @@ generator_lattice_2d(
     double y[] = NULL,
     double z[] = NULL)
 {
-   // Determine radius of the domain as a radius of inscribed sphere
-   double radius = 0.0;
-   if(domain_type == 1 || domain_type == 0) {
-      radius = bbox_max[0] - bbox_min[0];
-      if (radius > bbox_max[1] - bbox_min[1])
-          radius = bbox_max[1] - bbox_min[1];
-   }
-   radius = 0.5*radius;
-
-   // Central coordinates: in most cases this should be centered at (0,0)
-   double x_c = (bbox_max[0]+bbox_min[0])/2.;
-   double y_c = (bbox_max[1]+bbox_min[1])/2.;
-
    // Coordinate extents
    double xmin = bbox_min[0], xmax = bbox_max[0];
    double ymin = bbox_min[1], ymax = bbox_max[1];
@@ -222,10 +165,7 @@ generator_lattice_2d(
    if (lattice_type==0) { // rectangular lattice
      for(double y_p=ymin; y_p<ymax; y_p+=dx)
      for(double x_p=xmin; x_p<xmax; x_p+=dx)
-     if(in_domain_2d(x_p,y_p,
-                     x_c,y_c,
-                     bbox_min,bbox_max,
-                     radius,domain_type)){
+     if(in_domain_2d(x_p,y_p, bbox_min,bbox_max, domain_type)){
        if(!count_only){
          x[posid] = x_p;
          y[posid] = y_p;
@@ -238,10 +178,7 @@ generator_lattice_2d(
    else { // triangular lattice
      for(double y_p=ymin,    yo=0; y_p<ymax; y_p+=dy,yo=1-yo)
      for(double x_p=xmin +yo*dx/2; x_p<xmax; x_p+=dx)
-     if(in_domain_2d(x_p,y_p,
-                     x_c,y_c,
-                     bbox_min,bbox_max,
-                     radius,domain_type)){
+     if(in_domain_2d(x_p,y_p, bbox_min,bbox_max, domain_type)) {
        if(!count_only){
          x[posid] = x_p;
          y[posid] = y_p;
@@ -268,21 +205,6 @@ generator_lattice_3d(
     double y[] = NULL,
     double z[] = NULL)
 {
-   // Determine radius of the domain as a radius of inscribed sphere
-   double radius = 0.0;
-   if(domain_type==1 || domain_type==0) {
-      radius = bbox_max[0] - bbox_min[0];
-      for(size_t j=1;j<gdimension;j++)
-        if (radius > bbox_max[j] - bbox_min[j])
-          radius = bbox_max[j] - bbox_min[j];
-   }
-   radius = 0.5*radius;
-
-   // Central coordinates: in most cases this should be centered at (0,0,0)
-   double x_c = (bbox_max[0]+bbox_min[0])/2.;
-   double y_c = (bbox_max[1]+bbox_min[1])/2.;
-   double z_c = (bbox_max[2]+bbox_min[2])/2.;
-
    // True number of particles to be determined and returned
    int64_t tparticles = 0;
 
@@ -301,10 +223,7 @@ generator_lattice_3d(
      for(double z_p=xmin; z_p<zmax; z_p+=dx)
      for(double y_p=ymin; y_p<ymax; y_p+=dx)
      for(double x_p=zmin; x_p<xmax; x_p+=dx)
-     if(in_domain_3d(x_p,y_p,z_p,
-                     x_c,y_c,z_c,
-                     bbox_min,bbox_max,
-                     radius,domain_type)) {
+     if(in_domain_3d(x_p,y_p,z_p, bbox_min,bbox_max, domain_type)) {
        tparticles++;
        if(!count_only){
          x[posid] = x_p;
@@ -318,10 +237,7 @@ generator_lattice_3d(
      for(double z_p=zmin,         zo=0; z_p<zmax; z_p+=dz, zo=1-zo)
      for(double y_p=ymin-zo*dy/3, yo=0; y_p<ymax; y_p+=dy, yo=1-yo)
      for(double x_p=xmin+(yo-zo)*dx/2.; x_p<xmax; x_p+=dx)
-     if(in_domain_3d(x_p,y_p,z_p,
-                     x_c,y_c,z_c,
-                     bbox_min,bbox_max,
-                     radius,domain_type)){
+     if(in_domain_3d(x_p,y_p,z_p, bbox_min,bbox_max, domain_type)) {
        if(!count_only){
          x[posid] = x_p;
          y[posid] = y_p;
@@ -335,10 +251,7 @@ generator_lattice_3d(
      for(double z_p=zmin,         zl=0; z_p<zmax; z_p+=dz, zl=(zl+1)*(zl<3))
      for(double y_p=ymin-zl*dy/3, yo=0; y_p<ymax; y_p+=dy, yo=1-yo)
      for(double x_p=xmin+(yo-zl)*dx/2.; x_p<xmax; x_p+=dx)
-     if(in_domain_3d(x_p,y_p,z_p,
-                     x_c,y_c,z_c,
-                     bbox_min,bbox_max,
-                     radius,domain_type)) {
+     if(in_domain_3d(x_p,y_p,z_p, bbox_min,bbox_max, domain_type)) {
        if(!count_only){
          x[posid] = x_p;
          y[posid] = y_p;

--- a/include/params.h
+++ b/include/params.h
@@ -185,6 +185,12 @@ namespace param {
 // Geometric parameters
 //
 //- rectangular configuration parameters (e.g. sodtube in 2D/3D)
+
+// in various tests: sets the type of the domain (0:box, 1:sphere/circle)
+# ifndef domain_type
+  DECLARE_PARAM(int,domain_type,0)
+# endif
+
 #ifndef box_length
   DECLARE_PARAM(double,box_length,3.0)
 #endif
@@ -391,11 +397,6 @@ namespace param {
   DECLARE_PARAM(int,lattice_type,0)
 # endif
 
-// in Sedov test: set the lattice types
-# ifndef domain_type
-  DECLARE_PARAM(int,domain_type,0)
-# endif
-
 // in several tests: initial velocity of the flow
 # ifndef flow_velocity
   DECLARE_PARAM(double,flow_velocity,0.0)
@@ -535,6 +536,10 @@ void set_param(const std::string& param_name,
 # endif 
 
   // geometric configuration  -----------------------------------------------
+# ifndef domain_type
+  READ_NUMERIC_PARAM(domain_type)
+# endif
+
 # ifndef box_length
   READ_NUMERIC_PARAM(box_length)
 # endif
@@ -684,10 +689,6 @@ void set_param(const std::string& param_name,
 
 # ifndef lattice_type
   READ_NUMERIC_PARAM(lattice_type)
-# endif
-
-# ifndef domain_type
-  READ_NUMERIC_PARAM(domain_type)
 # endif
 
 # ifndef flow_velocity

--- a/include/physics/default_physics.h
+++ b/include/physics/default_physics.h
@@ -697,11 +697,8 @@ namespace physics{
    * 
    * ha = eta/N \sum_b pow(m_b / rho_b,1/dimension)
    */
-  void
-  compute_average_smoothinglength(
-      std::vector<body_holder*>& bodies,
-      int64_t nparticles)
-  {
+  void compute_average_smoothinglength( std::vector<body_holder*>& bodies,
+      int64_t nparticles) {
     // Compute the total 
     double total = 0.;
     for(auto b: bodies) {
@@ -711,7 +708,7 @@ namespace physics{
     // Add up with all the processes 
     MPI_Allreduce(MPI_IN_PLACE,&total,1,MPI_DOUBLE,MPI_SUM,MPI_COMM_WORLD);
     // Compute the new smoothing length 
-    double new_h = sph_eta/(double)nparticles * total;
+    double new_h = sph_eta*kernels::kernel_width/(double)nparticles * total;
     for(auto b: bodies) { 
       b->getBody()->setSmoothinglength(new_h);
     }

--- a/include/physics/kernels.h
+++ b/include/physics/kernels.h
@@ -83,6 +83,9 @@ namespace kernels{
     sinc_sigma[1] = 4.*(si_b0[1] + si_b1[1]*si + si_b2[1]/si + si_b3[1]/s2);
     sinc_sigma[2] = 8.*(si_b0[2] + si_b1[2]*sq + si_b2[2]*si + si_b3[2]*sq*si);
   }
+ 
+  // Connection to the sph_eta parameter
+  static double kernel_width = 1.0;
 
 /*============================================================================*/
 /*   Cubic spline                                                             */
@@ -679,10 +682,12 @@ namespace kernels{
     if (boost::iequals(kstr,"cubic spline")) {
       kernel = cubic_spline;
       gradKernel = gradient_cubic_spline;
+      kernel_width = 2.0;
     }
     else if (boost::iequals(kstr, "quintic spline")) {
       kernel = quintic_spline;
       gradKernel = gradient_quintic_spline;
+      kernel_width = 3.0;
     }
     else if (boost::iequals(kstr, "wendland c2")) {
       if (gdimension == 1) {
@@ -692,6 +697,7 @@ namespace kernels{
         kernel = wendland_c2_23d;
         gradKernel = gradient_wendland_c2_23d;
       }
+      kernel_width = 1.0;
     }
     else if (boost::iequals(kstr, "wendland c4")) {
       if (gdimension == 1) {
@@ -701,6 +707,7 @@ namespace kernels{
         kernel = wendland_c4_23d;
         gradKernel = gradient_wendland_c4_23d;
       }
+      kernel_width = 1.0;
     }
     else if (boost::iequals(kstr, "wendland c6")) {
       if (gdimension == 1) {
@@ -710,19 +717,23 @@ namespace kernels{
         kernel = wendland_c6_23d;
         gradKernel = gradient_wendland_c6_23d;
       }
+      kernel_width = 1.0;
     }
     else if (boost::iequals(kstr, "gaussian")) {
       kernel = gaussian;
       gradKernel = gradient_gaussian;
+      kernel_width = 3.0;
     }
     else if (boost::iequals(kstr, "super gaussian")) {
       kernel = super_gaussian;
       gradKernel = gradient_super_gaussian;
+      kernel_width = 3.0;
     }
     else if (boost::iequals(kstr, "sinc")) {
       set_sinc_kernel_normalization(param::sph_sinc_index);
       kernel = sinc_ker;
       gradKernel = gradient_sinc_ker;
+      kernel_width = 2.0;
     }
     else {
       clog_one(fatal) << "Bad kernel parameter" << std::endl;

--- a/include/physics/kernels.h
+++ b/include/physics/kernels.h
@@ -697,7 +697,7 @@ namespace kernels{
         kernel = wendland_c2_23d;
         gradKernel = gradient_wendland_c2_23d;
       }
-      kernel_width = 1.0;
+      kernel_width = 2.0;
     }
     else if (boost::iequals(kstr, "wendland c4")) {
       if (gdimension == 1) {
@@ -707,7 +707,7 @@ namespace kernels{
         kernel = wendland_c4_23d;
         gradKernel = gradient_wendland_c4_23d;
       }
-      kernel_width = 1.0;
+      kernel_width = 2.0;
     }
     else if (boost::iequals(kstr, "wendland c6")) {
       if (gdimension == 1) {
@@ -717,7 +717,7 @@ namespace kernels{
         kernel = wendland_c6_23d;
         gradKernel = gradient_wendland_c6_23d;
       }
-      kernel_width = 1.0;
+      kernel_width = 2.0;
     }
     else if (boost::iequals(kstr, "gaussian")) {
       kernel = gaussian;


### PR DESCRIPTION
Several small but important changes in sedov test, lattice.h and in kernels.h:
 - switch from setting sph_separation to geometric parameters in the test: this way, if we want to increase the number of particles, we don't have to recompute sph_separation and density every time.
The problem is defined in terms of box size (length / width / height) and initial density / pressure.
 - in kernel.h: introduced variable kernel_width to setup smoothing length;
 - somewhat unimportant but still: introduced box setup in sedov (explosion in a box rather than a sphere);
 - simplified and cleaned up interfaces in lattice.h.