### PR TITLE
(-) sedov_blast_radius is now in absolute units not sm. length

### DIFF
--- a/app/id_generators/sedov/main.cc
+++ b/app/id_generators/sedov/main.cc
@@ -61,7 +61,6 @@ void print_usage() {
 // derived parameters
 //
 static double timestep = 1.0;         // Recommended timestep
-static double r_blast = 0.;           // Radius of injection region
 static double total_mass = 1.;        // total mass of the fluid
 static double mass_particle = 1.;     // mass of an individual particle
 static point_t bbox_max, bbox_min;    // bounding box of the domain
@@ -144,9 +143,6 @@ void set_derived_params() {
 
   // intial internal energy
   SET_PARAM(uint_initial, (pressure_initial/(rho_initial*(poly_gamma-1.0))));
-
-  // Radius of injection region
-  r_blast = sedov_blast_radius * sph_separation;
 
   // Filename to be generated
   bool input_single_file = H5P_fileExists(initial_data_prefix);  
@@ -243,7 +239,7 @@ int main(int argc, char * argv[]){
   for(int64_t a=0L; a<nparticles; ++a) {
     body& particle = bodies[a];
     double r = norm2(particle.coordinates());
-    if (r < r_blast) {
+    if (r < sedov_blast_radius) {
        particles_blast++;
        mass_blast += mass_particle;
     }
@@ -306,7 +302,7 @@ int main(int argc, char * argv[]){
 
     // set internal energy
     double u_a = K0*pow(rho_a,poly_gamma-1)/(poly_gamma-1);
-    if (r < r_blast) 
+    if (r < sedov_blast_radius) 
       u_a += u_blast;
       //u_a += sedov_blast_energy/particles_blast;
     particle.setInternalenergy(u_a);

--- a/data/sedov_nx20.par
+++ b/data/sedov_nx20.par
@@ -10,7 +10,7 @@
   sphere_radius = 1.0
   sph_eta = 1.2
   sedov_blast_energy = 2.e-7
-  sedov_blast_radius = 1.0 # in units of particle separation
+  sedov_blast_radius = 0.06 
   lattice_type = 2         # 0:rectangular, 1:hcp, 2:fcc, 3:spherical
                            # (in 2d both hcp and fcc are triangular)
   domain_type = 1          # 0:box, 1:sphere

--- a/include/params.h
+++ b/include/params.h
@@ -512,7 +512,7 @@ typedef enum sph_kernel_keyword_enum {
 // in Sedov test: radius of energy injection
 // (in units of particle separation)
 # ifndef sedov_blast_radius
-  DECLARE_PARAM(double,sedov_blast_radius,1.0)
+  DECLARE_PARAM(double,sedov_blast_radius,0.05)
 # endif
 
 // in Noh test: infall velocity


### PR DESCRIPTION
The parameter 'sedov_blast_radius' specifies the radius of energy injection. 
Previously this parameter was in smoothing length units, which means that if you were to increase particle resolution, say by a factor of ten, your radius of energy injection would automatically shrink by a factor of ten too. As a result, internal energy and pressure inside the blast region become resolution-dependent and arbitrarily large. This in turn affects the adaptive timestep, which is sensitive to the pressure contrast.

Therefore, for doing fair resolution studies, you would have to increase sedov_blast_radius manually, which is prone to errors. To avoid this, it is now set it to be expressed in absolute units.