### PR TITLE
Fix/hlim/python3 compatible

### DIFF
--- a/tools/1D_reduction.py
+++ b/tools/1D_reduction.py
@@ -20,7 +20,7 @@ import argparse
 
 
 def create_output(dataset):
-    print dataset
+    print (dataset)
 
     # Get timestep number
     s = dataset[5:]
@@ -45,14 +45,14 @@ def create_output(dataset):
     z_rc = z_data - z_c
     rad_distance = np.sqrt(np.multiply(x_rc, x_rc) + np.multiply(y_rc, y_rc) + np.multiply(z_rc, z_rc))
 
-    #print i, np.max(rad_distance)
+    print (i, np.max(rad_distance))
 
     # Create table
     head = 'column1:x, column2:y, column3:z, column4:r, column5:rho, column6:P, column7:u'
     data = np.column_stack((x_data, y_data, z_data, rad_distance, rho_data, P_data, u_data))
 
 #    # Write table
-    with open("1d_output_{0:05d}.dat".format(i), 'w+') as datafile_id:
+    with open("1d_output_{0:05d}.dat".format(i), 'wb+') as datafile_id:
         np.savetxt(datafile_id, data, fmt='%04.03e', header = head)
     return;
 

--- a/tools/nsID_tov/binary.py
+++ b/tools/nsID_tov/binary.py
@@ -1,7 +1,7 @@
 # Copyright (c) 2017 Triad National Security, LLC
 # All rights reserved.
 
-#!/usr/bin/env python3
+#!/usr/bin/env python
 
 # Author : Hyun Lim
 # Date : Jun3.27.2017

--- a/tools/nsID_tov/tov_solver_h5part.py
+++ b/tools/nsID_tov/tov_solver_h5part.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env python
 
 # Author : Hyun Lim
 # Date : June.26.2017


### PR DESCRIPTION
Update several scripts that are compatible with python3 not python 2.7

I checked all current scripts but it is good to check again. 
1D_reduction.py is updated 
binary.py and tov_solver_h5part.py for TOV NS ID are changed python3 to python in env def. (i.e. everyone mush call python3 as default)