### PR TITLE
(+) .codecov.yml

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,9 +1,9 @@
 ignore:
-  - /usr/include/
-  - /usr/local/include/
-  - cinch/
-  - include/tree_topology/test/
-  - include/physics/test/
-  - app/drivers/test/
-  - mpisph/test/
+  - ".*/usr/include"
+  - ".*/usr/local/include"
+  - ".*/cinch"
+  - ".*/include/tree_topology/test"
+  - ".*/include/physics/test"
+  - ".*/app/drivers/test"
+  - ".*/mpisph/test"
 


### PR DESCRIPTION
Code Coverage config script: instruct codecov to ignore
/usr, cinch and test directories